### PR TITLE
fix: manual screen header

### DIFF
--- a/src/navigation/AppStack/AppStack.tsx
+++ b/src/navigation/AppStack/AppStack.tsx
@@ -41,7 +41,6 @@ const AppStack = () => {
 			<Stack.Screen
 				name={AppStackScreens.ManualTransaction}
 				component={ManualTransactionScreen}
-				options={{ headerShown: true, title: 'Manual Transaction' }}
 			/>
 		</Stack.Navigator>
 	);


### PR DESCRIPTION
This pull request makes a minor update to the navigation stack configuration. The change removes the custom header options for the `ManualTransaction` screen, so it will now use the default header settings instead of a custom title.

- Removed the explicit `options` prop (custom header and title) from the `ManualTransaction` screen in `AppStack`, reverting it to default navigation behavior.