### PR TITLE
fix: home screen keyboard

### DIFF
--- a/src/navigation/AppStack/AppStack.tsx
+++ b/src/navigation/AppStack/AppStack.tsx
@@ -41,7 +41,6 @@ const AppStack = () => {
 			<Stack.Screen
 				name={AppStackScreens.ManualTransaction}
 				component={ManualTransactionScreen}
-				options={{ headerShown: true, title: 'Manual Transaction' }}
 			/>
 		</Stack.Navigator>
 	);

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -7,6 +7,7 @@ import ThemedScreen from '@components/ThemedScreen/ThemedScreen';
 import TransactionsTable from '@components/TransactionsTable/TransactionsTable';
 import { TestID } from '@enums/TestID';
 import useGreeting from '@hooks/useGreeting';
+import useKeyboardShift from '@hooks/useKeyboardShift';
 import useLoadThread from '@hooks/useLoadThread';
 import { useReactiveAIMessages } from '@hooks/useReactiveAIMessages';
 import { useReactiveTransactions } from '@hooks/useReactiveTransactions';
@@ -63,6 +64,8 @@ const HomeScreen = (_props: Props) => {
 	const [displayedView, setDisplayedView] = useState<
 		'chat' | 'transactions'
 	>('chat');
+	const { keyboardShift, dismissKeyboardOnTouchCapture } =
+		useKeyboardShift({ keyboardOffset: 160 });
 	const contentOpacity = useRef(new Animated.Value(1)).current;
 	const contentTranslateY = useRef(new Animated.Value(0)).current;
 	const pillProgress = useRef(new Animated.Value(0)).current;
@@ -192,126 +195,138 @@ const HomeScreen = (_props: Props) => {
 
 	return (
 		<ThemedScreen testID={TestID.HomeScreen}>
-			<View style={styles.screen}>
-				<View style={styles.header}>
-					<AppText style={styles.eyebrow}>Assistant</AppText>
-					<AppText variant="titleLarge" style={styles.title}>
-						Budget AI
-					</AppText>
-				</View>
-				<View style={styles.balanceSection}>
-					<BalanceHeader balance={balance} />
-				</View>
-				<View
-					style={styles.toggleContainer}
-					onLayout={(event) => {
-						setToggleWidth(event.nativeEvent.layout.width);
-					}}>
-					<Animated.View
-						pointerEvents="none"
-						style={[
-							styles.togglePillIndicator,
-							{
-								width: toggleWidth
-									? toggleWidth / 2 - 4
-									: 0,
-								transform: [
-									{
-										translateX: Animated.multiply(
-											pillProgress,
-											toggleWidth
-												? toggleWidth / 2
-												: 0,
-										),
-									},
-								],
-							},
-						]}
-					/>
-					<Pressable
-						testID={`${TestID.HomeScreen}-ViewChatPill`}
-						onPress={() => {
-							setActiveView('chat');
-						}}
-						style={({ pressed }) => [
-							styles.togglePill,
-							pressed && styles.togglePillPressed,
-						]}>
-						<AppText
-							style={[
-								styles.toggleLabel,
-								activeView === 'chat' &&
-									styles.toggleLabelActive,
-							]}>
-							Chat
+			<Animated.View
+				style={[
+					styles.flex,
+					{ transform: [{ translateY: keyboardShift }] },
+				]}
+				onStartShouldSetResponderCapture={
+					dismissKeyboardOnTouchCapture
+				}>
+				<View style={styles.screen}>
+					<View style={styles.header}>
+						<AppText style={styles.eyebrow}>Assistant</AppText>
+						<AppText variant="titleLarge" style={styles.title}>
+							Budget AI
 						</AppText>
-					</Pressable>
-					<Pressable
-						testID={`${TestID.HomeScreen}-ViewTransactionsPill`}
-						onPress={() => {
-							setActiveView('transactions');
-						}}
-						style={({ pressed }) => [
-							styles.togglePill,
-							pressed && styles.togglePillPressed,
-						]}>
-						<AppText
+					</View>
+					<View style={styles.balanceSection}>
+						<BalanceHeader balance={balance} />
+					</View>
+					<View
+						style={styles.toggleContainer}
+						onLayout={(event) => {
+							setToggleWidth(event.nativeEvent.layout.width);
+						}}>
+						<Animated.View
+							pointerEvents="none"
 							style={[
-								styles.toggleLabel,
-								activeView === 'transactions' &&
-									styles.toggleLabelActive,
+								styles.togglePillIndicator,
+								{
+									width: toggleWidth
+										? toggleWidth / 2 - 4
+										: 0,
+									transform: [
+										{
+											translateX: Animated.multiply(
+												pillProgress,
+												toggleWidth
+													? toggleWidth / 2
+													: 0,
+											),
+										},
+									],
+								},
+							]}
+						/>
+						<Pressable
+							testID={`${TestID.HomeScreen}-ViewChatPill`}
+							onPress={() => {
+								setActiveView('chat');
+							}}
+							style={({ pressed }) => [
+								styles.togglePill,
+								pressed && styles.togglePillPressed,
 							]}>
-							Transactions
-						</AppText>
-					</Pressable>
+							<AppText
+								style={[
+									styles.toggleLabel,
+									activeView === 'chat' &&
+										styles.toggleLabelActive,
+								]}>
+								Chat
+							</AppText>
+						</Pressable>
+						<Pressable
+							testID={`${TestID.HomeScreen}-ViewTransactionsPill`}
+							onPress={() => {
+								setActiveView('transactions');
+							}}
+							style={({ pressed }) => [
+								styles.togglePill,
+								pressed && styles.togglePillPressed,
+							]}>
+							<AppText
+								style={[
+									styles.toggleLabel,
+									activeView === 'transactions' &&
+										styles.toggleLabelActive,
+								]}>
+								Transactions
+							</AppText>
+						</Pressable>
+					</View>
+					<View style={styles.chatContainer}>
+						<Animated.View
+							style={[
+								styles.animatedContent,
+								{
+									opacity: contentOpacity,
+									transform: [
+										{ translateY: contentTranslateY },
+									],
+								},
+							]}>
+							{displayedView === 'chat' ? (
+								<AiChatView
+									threadId={threadId}
+									messages={messages}
+								/>
+							) : (
+								<View style={styles.transactionsContainer}>
+									{tableTransactions.length ? (
+										<TransactionsTable
+											transactions={tableTransactions}
+										/>
+									) : (
+										<AppText
+											style={
+												styles.emptyTransactionsText
+											}>
+											No transactions yet.
+										</AppText>
+									)}
+								</View>
+							)}
+						</Animated.View>
+					</View>
+					<View style={styles.footer}>
+						<ActionButtonList
+							items={footerActions}
+							onPressItem={handleFooterAction}
+						/>
+					</View>
 				</View>
-				<View style={styles.chatContainer}>
-					<Animated.View
-						style={[
-							styles.animatedContent,
-							{
-								opacity: contentOpacity,
-								transform: [
-									{ translateY: contentTranslateY },
-								],
-							},
-						]}>
-						{displayedView === 'chat' ? (
-							<AiChatView
-								threadId={threadId}
-								messages={messages}
-							/>
-						) : (
-							<View style={styles.transactionsContainer}>
-								{tableTransactions.length ? (
-									<TransactionsTable
-										transactions={tableTransactions}
-									/>
-								) : (
-									<AppText
-										style={
-											styles.emptyTransactionsText
-										}>
-										No transactions yet.
-									</AppText>
-								)}
-							</View>
-						)}
-					</Animated.View>
-				</View>
-				<View style={styles.footer}>
-					<ActionButtonList
-						items={footerActions}
-						onPressItem={handleFooterAction}
-					/>
-				</View>
-			</View>
+			</Animated.View>
 		</ThemedScreen>
 	);
 };
 
 const createStyles = (colors: AppColors) =>
 	StyleSheet.create({
+		flex: {
+			flex: 1,
+		},
 		screen: {
 			flex: 1,
 			backgroundColor: colors.neutral.background,

--- a/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
+++ b/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
@@ -42,9 +42,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 	const { colors, isDarkMode } = useTheme();
 	const styles = useMemo(() => createStyles(colors), [colors]);
 	const { keyboardShift, dismissKeyboardOnTouchCapture } =
-		useKeyboardShift({
-			keyboardOffset: 100,
-		});
+		useKeyboardShift({ keyboardOffset: 100 });
 
 	const [amount, setAmount] = useState('');
 	const [merchant, setMerchant] = useState('');


### PR DESCRIPTION
This pull request primarily improves keyboard handling and user experience on the `HomeScreen` by integrating the `useKeyboardShift` hook and updating the layout to respond to keyboard visibility. Additionally, it removes an unnecessary screen option and makes a minor code style update in `ManualTransactionScreen`.

Keyboard handling and layout improvements:

* Integrated the `useKeyboardShift` hook into `HomeScreen`, allowing the main content to shift up when the keyboard appears, preventing it from being obscured. The hook is initialized with a `keyboardOffset` of 160. (`src/screens/HomeScreen/HomeScreen.tsx`) [[1]](diffhunk://#diff-e09a5b09054d94f83d1b00498441db2c615cebe10ed66aade31ac34994d616acR10) [[2]](diffhunk://#diff-e09a5b09054d94f83d1b00498441db2c615cebe10ed66aade31ac34994d616acR67-R68)
* Wrapped the main content of `HomeScreen` in an `Animated.View` that applies the keyboard shift transform and dismisses the keyboard on outside touches, improving usability during text input. (`src/screens/HomeScreen/HomeScreen.tsx`) [[1]](diffhunk://#diff-e09a5b09054d94f83d1b00498441db2c615cebe10ed66aade31ac34994d616acR198-R205) [[2]](diffhunk://#diff-e09a5b09054d94f83d1b00498441db2c615cebe10ed66aade31ac34994d616acR320-R329)
* Added a reusable `flex` style to support the new animated wrapper. (`src/screens/HomeScreen/HomeScreen.tsx`)

Other changes:

* Removed the explicit `headerShown` and `title` options from the `ManualTransaction` screen in the navigation stack, likely to use default navigation header behavior. (`src/navigation/AppStack/AppStack.tsx`)
* Minor code style update in `ManualTransactionScreen` for the `useKeyboardShift` hook instantiation. (`src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx`)