### PR TITLE
feat: add auth

### DIFF
--- a/.agents/skills/auth0-react-native/SKILL.md
+++ b/.agents/skills/auth0-react-native/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: auth0-react-native
+description: Use when adding authentication to React Native or Expo mobile apps (iOS/Android) with biometric support - integrates react-native-auth0 SDK with native deep linking
+license: Apache-2.0
+metadata:
+    author: Auth0 <support@auth0.com>
+    version: '1.0.0'
+    openclaw:
+        emoji: "\U0001F510"
+        homepage: https://github.com/auth0/agent-skills
+---
+
+# Auth0 React Native Integration
+
+Add authentication to React Native and Expo mobile applications using react-native-auth0.
+
+---
+
+## Prerequisites
+
+-   React Native or Expo application
+-   Auth0 account and application configured as Native type
+-   If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+-   **Expo managed workflow** - Use `auth0-expo` skill for Expo apps with config plugin
+-   **React web applications** - Use `auth0-react` skill for SPAs (Vite/CRA)
+-   **React Server Components** - Use `auth0-nextjs` for Next.js applications
+-   **Non-React native apps** - Use platform-specific SDKs (Swift for iOS, Kotlin for Android)
+-   **Backend APIs** - Use JWT validation libraries for your server language
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+**Expo:**
+
+```bash
+npx expo install react-native-auth0
+```
+
+**React Native CLI:**
+
+```bash
+npm install react-native-auth0
+npx pod-install  # iOS only
+```
+
+### 2. Configure Environment
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup:**
+
+Create `.env`:
+
+```bash
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=your-client-id
+```
+
+### 3. Configure Native Platforms
+
+**iOS** - Update `ios/{YourApp}/Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>None</string>
+    <key>CFBundleURLName</key>
+    <string>auth0</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>$(PRODUCT_BUNDLE_IDENTIFIER).auth0</string>
+    </array>
+  </dict>
+</array>
+```
+
+**Android** - Update `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name="com.auth0.android.provider.RedirectActivity"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:host="YOUR_AUTH0_DOMAIN"
+            android:pathPrefix="/android/${applicationId}/callback"
+            android:scheme="${applicationId}" />
+    </intent-filter>
+</activity>
+```
+
+**Expo** - Update `app.json`:
+
+```json
+{
+	"expo": {
+		"scheme": "your-app-scheme",
+		"ios": {
+			"bundleIdentifier": "com.yourcompany.yourapp"
+		},
+		"android": {
+			"package": "com.yourcompany.yourapp"
+		}
+	}
+}
+```
+
+### 4. Add Authentication with Auth0Provider
+
+Wrap your app with `Auth0Provider`:
+
+```typescript
+import React from 'react';
+import { Auth0Provider } from 'react-native-auth0';
+import App from './App';
+
+export default function Root() {
+	return (
+		<Auth0Provider
+			domain={process.env.AUTH0_DOMAIN}
+			clientId={process.env.AUTH0_CLIENT_ID}>
+			<App />
+		</Auth0Provider>
+	);
+}
+```
+
+### 5. Use the useAuth0 Hook
+
+```typescript
+import React from 'react';
+import { View, Button, Text, ActivityIndicator } from 'react-native';
+import { useAuth0 } from 'react-native-auth0';
+
+export default function App() {
+	const { user, authorize, clearSession, isLoading } = useAuth0();
+
+	const login = async () => {
+		try {
+			await authorize({
+				scope: 'openid profile email',
+			});
+		} catch (error) {
+			console.error('Login error:', error);
+		}
+	};
+
+	const logout = async () => {
+		try {
+			await clearSession();
+		} catch (error) {
+			console.error('Logout error:', error);
+		}
+	};
+
+	if (isLoading) {
+		return <ActivityIndicator />;
+	}
+
+	return (
+		<View>
+			{user ? (
+				<>
+					<Text>Welcome, {user.name}!</Text>
+					<Text>{user.email}</Text>
+					<Button title="Logout" onPress={logout} />
+				</>
+			) : (
+				<Button title="Login" onPress={login} />
+			)}
+		</View>
+	);
+}
+```
+
+### 6. Test Authentication
+
+**Expo:**
+
+```bash
+npx expo start
+```
+
+**React Native:**
+
+```bash
+npx react-native run-ios
+# or
+npx react-native run-android
+```
+
+---
+
+## Detailed Documentation
+
+-   **[Setup Guide](references/setup.md)** - Automated setup, native configuration, deep linking
+-   **[Patterns Guide](references/patterns.md)** - Secure storage, biometric auth, token refresh
+-   **[API Reference](references/api.md)** - Complete SDK API, methods, configuration options
+
+---
+
+## Common Mistakes
+
+| Mistake                               | Fix                                                                                                                                     |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Forgot to wrap app with Auth0Provider | All components using useAuth0() must be children of Auth0Provider                                                                       |
+| Forgot to configure deep linking      | Add URL scheme to iOS Info.plist and Android AndroidManifest.xml (see Step 3)                                                           |
+| Callback URL mismatch                 | Ensure callback URL in Auth0 Dashboard matches your app's URL scheme (e.g., `com.yourapp.auth0://YOUR_DOMAIN/ios/com.yourapp/callback`) |
+| iOS build fails after install         | Run `npx pod-install` to link native dependencies                                                                                       |
+| App created as SPA type in Auth0      | Must be Native application type for mobile apps                                                                                         |
+| Not handling auth errors              | Wrap authorize/clearSession calls in try-catch blocks                                                                                   |
+| Deep link not working on Android      | Verify `android:exported="true"` is set on RedirectActivity                                                                             |
+
+---
+
+## Related Skills
+
+-   `auth0-quickstart` - Basic Auth0 setup
+-   `auth0-migration` - Migrate from another auth provider
+-   `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Core Hook API:**
+
+-   `useAuth0()` - Main hook for authentication
+-   `authorize()` - Initiate login
+-   `clearSession()` - Logout
+-   `user` - User profile object
+-   `getCredentials()` - Get tokens for API calls
+-   `isLoading` - Loading state
+
+**Common Use Cases:**
+
+-   Login/Logout → See Step 5 above
+-   Secure token storage → Automatic with `Auth0Provider`
+-   Biometric authentication → [Patterns Guide](references/patterns.md#biometric-auth)
+-   API calls with tokens → [Patterns Guide](references/patterns.md#calling-apis)
+-   Token refresh → Automatic with `getCredentials()`
+
+---
+
+## References
+
+-   [Auth0 React Native SDK Documentation](https://auth0.com/docs/libraries/react-native-auth0)
+-   [Auth0 React Native Quickstart](https://auth0.com/docs/quickstart/native/react-native)
+-   [SDK GitHub Repository](https://github.com/auth0/react-native-auth0)

--- a/.agents/skills/auth0-react-native/references/api.md
+++ b/.agents/skills/auth0-react-native/references/api.md
@@ -1,0 +1,63 @@
+## Testing
+
+### iOS Testing
+
+1. Run the app: `npx react-native run-ios` or `npx expo run:ios`
+2. Tap "Login" button
+3. Safari opens with Auth0 Universal Login
+4. Complete authentication
+5. App opens via deep link with user authenticated
+6. Tap "Logout" and verify session cleared
+
+### Android Testing
+
+1. Run the app: `npx react-native run-android` or `npx expo run:android`
+2. Tap "Login" button
+3. Chrome Custom Tabs opens with Auth0 login
+4. Complete authentication
+5. App resumes via intent filter with user authenticated
+6. Tap "Logout" and verify session cleared
+
+---
+
+## Common Issues
+
+| Issue                                 | Solution                                                              |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| Deep link not working (iOS)           | Check `CFBundleURLSchemes` matches bundle identifier exactly          |
+| Deep link not working (Android)       | Verify `android:scheme` and `android:host` in AndroidManifest.xml     |
+| "Invalid state" error                 | Clear app data and reinstall. Check callback URLs match configuration |
+| Login opens but doesn't return to app | Ensure deep linking is properly configured and tested                 |
+| Expo build fails                      | Run `npx expo prebuild` to generate native configuration              |
+| iOS builds fail after pod install     | Run `cd ios && pod deintegrate && pod install`                        |
+
+---
+
+## Security Considerations
+
+-   **Use secure storage** - Credentials are stored securely using Keychain (iOS) and Keystore (Android)
+-   **HTTPS only** - Auth0 requires HTTPS callback URLs (except localhost for dev)
+-   **Validate tokens on backend** - Never trust client-side token validation
+-   **Use PKCE** - Enabled by default with react-native-auth0
+-   **Implement biometric authentication** - Use react-native-biometrics with Auth0 for enhanced security
+-   **Handle token expiration** - Implement refresh token logic with `getCredentials()`
+
+---
+
+## Related Skills
+
+-   `auth0-quickstart` - Initial Auth0 account setup
+-   `auth0-migration` - Migrate from another auth provider
+-   `auth0-mfa` - Add Multi-Factor Authentication
+-   `auth0-passkeys` - Add passkey authentication
+-   `auth0-organizations` - B2B multi-tenancy support
+
+---
+
+## References
+
+-   [React Native Auth0 SDK Documentation](https://auth0.com/docs/libraries/auth0-react-native)
+-   [React Native Auth0 SDK GitHub](https://github.com/auth0/react-native-auth0)
+-   [Auth0 React Native Quickstart](https://auth0.com/docs/quickstart/native/react-native)
+-   [React Native Deep Linking](https://reactnative.dev/docs/linking)
+-   [Expo Deep Linking](https://docs.expo.dev/guides/deep-linking/)

--- a/.agents/skills/auth0-react-native/references/patterns.md
+++ b/.agents/skills/auth0-react-native/references/patterns.md
@@ -1,0 +1,196 @@
+## Common Patterns
+
+### Protected Screen with Navigation
+
+```tsx
+import { useAuth0 } from 'react-native-auth0';
+import { useEffect } from 'react';
+import { NavigationProp } from '@react-navigation/native';
+
+export function ProtectedScreen({
+	navigation,
+}: {
+	navigation: NavigationProp<any>;
+}) {
+	const { user, isLoading } = useAuth0();
+
+	useEffect(() => {
+		if (!isLoading && !user) {
+			navigation.navigate('Login');
+		}
+	}, [isLoading, user, navigation]);
+
+	if (isLoading) {
+		return <ActivityIndicator />;
+	}
+
+	if (!user) {
+		return null;
+	}
+
+	return (
+		<View>
+			<Text>Protected Content</Text>
+			<Text>User ID: {user.sub}</Text>
+		</View>
+	);
+}
+```
+
+---
+
+### Get User Profile
+
+```tsx
+import { useAuth0 } from 'react-native-auth0';
+import { View, Text, Image } from 'react-native';
+
+export function ProfileScreen() {
+	const { user } = useAuth0();
+
+	if (!user) {
+		return <Text>Please log in</Text>;
+	}
+
+	return (
+		<View>
+			{user.picture && (
+				<Image
+					source={{ uri: user.picture }}
+					style={{ width: 100, height: 100, borderRadius: 50 }}
+				/>
+			)}
+			<Text>Name: {user.name}</Text>
+			<Text>Email: {user.email}</Text>
+			<Text>
+				Email Verified: {user.email_verified ? 'Yes' : 'No'}
+			</Text>
+			<Text>User ID: {user.sub}</Text>
+		</View>
+	);
+}
+```
+
+---
+
+### Call Protected API
+
+```tsx
+import { useAuth0 } from 'react-native-auth0';
+import { useState } from 'react';
+import { View, Button, Text } from 'react-native';
+
+export function ApiTestScreen() {
+	const { getCredentials } = useAuth0();
+	const [data, setData] = useState(null);
+	const [error, setError] = useState(null);
+
+	const callApi = async () => {
+		try {
+			const credentials = await getCredentials();
+
+			const response = await fetch('https://your-api.com/data', {
+				headers: {
+					Authorization: `Bearer ${credentials.accessToken}`,
+				},
+			});
+
+			const json = await response.json();
+			setData(json);
+		} catch (err) {
+			setError(err.message);
+		}
+	};
+
+	return (
+		<View>
+			<Button title="Call API" onPress={callApi} />
+			{error && <Text>Error: {error}</Text>}
+			{data && <Text>{JSON.stringify(data, null, 2)}</Text>}
+		</View>
+	);
+}
+```
+
+**Note:** To call APIs, configure `audience` parameter:
+
+```tsx
+const login = async () => {
+	await authorize({
+		audience: 'https://your-api-identifier',
+		scope: 'openid profile email',
+	});
+};
+```
+
+---
+
+### Silent Authentication
+
+```tsx
+import { useAuth0 } from 'react-native-auth0';
+import { useEffect } from 'react';
+
+export function App() {
+	const { getCredentials, user } = useAuth0();
+
+	useEffect(() => {
+		// Attempt silent authentication on app start
+		const checkAuth = async () => {
+			try {
+				await getCredentials();
+			} catch (e) {
+				// User not logged in, do nothing
+			}
+		};
+
+		if (!user) {
+			checkAuth();
+		}
+	}, []);
+
+	// Rest of your app...
+}
+```
+
+---
+
+### Custom Login Options
+
+```tsx
+const login = async () => {
+	await authorize({
+		scope: 'openid profile email offline_access',
+		audience: 'https://your-api-identifier',
+		connection: 'google-oauth2', // Optional: force specific connection
+		prompt: 'login', // Force re-authentication
+	});
+};
+```
+
+---
+
+## Configuration Options
+
+### Complete Auth0Provider Configuration
+
+```tsx
+<Auth0Provider domain="your-tenant.auth0.com" clientId="your-client-id">
+	<App />
+</Auth0Provider>
+```
+
+### Complete authorize() Options
+
+```tsx
+await authorize({
+	scope: 'openid profile email offline_access',
+	audience: 'https://your-api-identifier',
+	connection: 'Username-Password-Authentication', // Optional
+	prompt: 'login', // or 'consent'
+	screen_hint: 'signup', // Show signup instead of login
+	max_age: 300, // Force re-auth if session older than 5 minutes
+});
+```
+
+---

--- a/.agents/skills/auth0-react-native/references/setup.md
+++ b/.agents/skills/auth0-react-native/references/setup.md
@@ -1,0 +1,149 @@
+# Auth0 React Native Setup Guide
+
+Setup instructions for React Native and Expo mobile applications.
+
+---
+
+## Quick Setup
+
+### For Expo
+
+```bash
+# Install SDK
+npx expo install react-native-auth0
+
+# Configure app.json
+# Add scheme, bundleIdentifier, and package
+```
+
+### For React Native CLI
+
+```bash
+# Install SDK
+npm install react-native-auth0
+
+# iOS: Install pods
+cd ios && pod install && cd ..
+
+# Configure iOS Info.plist and Android AndroidManifest.xml
+```
+
+---
+
+## Manual Setup
+
+### 1. Install SDK
+
+**Expo:**
+
+```bash
+npx expo install react-native-auth0
+```
+
+**React Native CLI:**
+
+```bash
+npm install react-native-auth0
+npx pod-install  # iOS only
+```
+
+### 2. Create Auth0 Native Application
+
+Via CLI:
+
+```bash
+auth0 login
+auth0 apps create --name "My Mobile App" --type native \
+  --callbacks "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
+  --logout-urls "com.yourcompany.yourapp.auth0://YOUR_DOMAIN/ios/com.yourcompany.yourapp/callback,com.yourcompany.yourapp.auth0://YOUR_DOMAIN/android/com.yourcompany.yourapp/callback" \
+  --metadata "created_by=agent_skills"
+```
+
+Via Dashboard:
+
+1. Create **Native** application type
+2. Configure callback URLs with your app scheme
+3. Copy domain and client ID
+
+### 3. Configure iOS
+
+Update `ios/{YourApp}/Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>None</string>
+    <key>CFBundleURLName</key>
+    <string>auth0</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>$(PRODUCT_BUNDLE_IDENTIFIER).auth0</string>
+    </array>
+  </dict>
+</array>
+```
+
+### 4. Configure Android
+
+Update `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<activity android:name="com.auth0.android.provider.RedirectActivity" android:exported="true">
+  <intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data
+      android:host="YOUR_DOMAIN"
+      android:pathPrefix="/android/${applicationId}/callback"
+      android:scheme="${applicationId}" />
+  </intent-filter>
+</activity>
+```
+
+### 5. Configure Expo
+
+Update `app.json`:
+
+```json
+{
+	"expo": {
+		"scheme": "myappscheme",
+		"ios": {
+			"bundleIdentifier": "com.mycompany.myapp"
+		},
+		"android": {
+			"package": "com.mycompany.myapp"
+		}
+	}
+}
+```
+
+---
+
+## Troubleshooting
+
+**Callback not working:**
+
+-   Verify scheme matches bundle ID/package name
+-   Check Auth0 allowed callbacks include your scheme
+
+**Build errors on iOS:**
+
+-   Run `pod install` in ios/ directory
+-   Clean build folder in Xcode
+
+**Android redirect issues:**
+
+-   Ensure RedirectActivity is exported
+-   Check scheme matches package name
+
+---
+
+## Next Steps
+
+-   [Patterns Guide](patterns.md) - Implementation patterns
+-   [API Reference](api.md) - Complete SDK API
+-   [Main Skill](../SKILL.md) - Quick start workflow

--- a/README.md
+++ b/README.md
@@ -113,3 +113,44 @@ yarn format:check
 ```sh
 BASE_URL=https://budget-ai-backend-f2124bc32a19.herokuapp.com
 ```
+
+### Auth0 Setup
+
+1. Install dependencies and iOS pods:
+
+```sh
+yarn install
+npx pod-install
+```
+
+2. Update Auth0 credentials in:
+
+```txt
+src/services/Auth0Service.ts
+```
+
+Set:
+
+```txt
+domain: YOUR_AUTH0_DOMAIN
+clientId: YOUR_AUTH0_CLIENT_ID
+```
+
+3. Update Android Auth0 domain placeholder in:
+
+```txt
+android/app/build.gradle
+```
+
+Set:
+
+```txt
+manifestPlaceholders = [auth0Domain: "YOUR_AUTH0_DOMAIN"]
+```
+
+4. In the Auth0 dashboard, register callback/logout URLs:
+
+-   iOS callback: `com.phung.budget-ai.auth0://YOUR_AUTH0_DOMAIN/ios/com.phung.budget-ai/callback`
+-   iOS logout: `com.phung.budget-ai.auth0://YOUR_AUTH0_DOMAIN/ios/com.phung.budget-ai/logout`
+-   Android callback: `com.budgetai://YOUR_AUTH0_DOMAIN/android/com.budgetai/callback`
+-   Android logout: `com.budgetai://YOUR_AUTH0_DOMAIN/android/com.budgetai/logout`

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -84,6 +84,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        manifestPlaceholders = [
+            auth0Domain: "YOUR_AUTH0_DOMAIN"
+        ]
     }
     signingConfigs {
         debug {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,5 +23,18 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+      <activity
+        android:name="com.auth0.android.provider.RedirectActivity"
+        android:exported="true">
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data
+            android:host="${auth0Domain}"
+            android:pathPrefix="/android/${applicationId}/callback"
+            android:scheme="${applicationId}" />
+        </intent-filter>
+      </activity>
     </application>
 </manifest>

--- a/ios/BudgetAI/Info.plist
+++ b/ios/BudgetAI/Info.plist
@@ -8,6 +8,19 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>BudgetAI</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>auth0</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER).auth0</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,27 @@
 PODS:
+  - A0Auth0 (5.5.1):
+    - Auth0 (= 2.18.0)
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - AsyncStorage (3.0.2):
     - hermes-engine
     - RCTRequired
@@ -21,10 +44,14 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - Auth0 (2.18.0):
+    - JWTDecode (= 3.3.0)
+    - SimpleKeychain (= 1.3.0)
   - FBLazyVector (0.85.2)
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
+  - JWTDecode (3.3.0)
   - op-sqlite (15.2.12):
     - hermes-engine
     - RCTRequired
@@ -1931,9 +1958,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - SimpleKeychain (1.3.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
+  - A0Auth0 (from `../node_modules/react-native-auth0`)
   - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2017,9 +2046,14 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - Auth0
+    - JWTDecode
     - Plaid
+    - SimpleKeychain
 
 EXTERNAL SOURCES:
+  A0Auth0:
+    :path: "../node_modules/react-native-auth0"
   AsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   FBLazyVector:
@@ -2179,9 +2213,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  A0Auth0: 6a412a3d1dec52bd9624bbe65b795140f9fc565a
   AsyncStorage: 857a13f3c66a30d6b02efa09babba3d457e8e8ca
+  Auth0: ddc5c6c7eb17e2484fd8d50a15d99b657c36c72c
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
   hermes-engine: b4b7cbfc35525b90e18ffa75c5fb29ec4b914cc1
+  JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631
   op-sqlite: 7aab3dd83d2c2cd28a050b6fd799b59a26b6006e
   Plaid: 2f4e0d6deb335e141ac62e082a872414ca058b74
   RCTDeprecation: c7a2768f905d76ca6d2cfefb26e4349eacbdfca3
@@ -2257,6 +2294,7 @@ SPEC CHECKSUMS:
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
   ReactNativeDependencies: 1c8c4bb4b4bab61473376042ddf9d54e7d45db65
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41
+  SimpleKeychain: 9c0f3ca8458fed74e01db864d181c5cbe278603e
   Yoga: df8920a8f8ca99996048f6aea23a529f44992eac
 
 PODFILE CHECKSUM: 58c9460442c1ef458592ffae3bab856287df01a5

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -112,6 +112,7 @@ const config: Config = {
 			'<rootDir>/jest/mocks/NativeAnimatedHelper.ts',
 		'^react-native/src/private/animated/NativeAnimatedHelper$':
 			'<rootDir>/jest/mocks/NativeAnimatedHelper.ts',
+		'^react-native-auth0$': '<rootDir>/jest/mocks/reactNativeAuth0.ts',
 		'^react-native-plaid-link-sdk$':
 			'<rootDir>/jest/mocks/reactNativePlaidLinkSdk.ts',
 	},

--- a/jest/mocks/reactNativeAuth0.ts
+++ b/jest/mocks/reactNativeAuth0.ts
@@ -1,0 +1,16 @@
+class Auth0 {
+	webAuth = {
+		authorize: jest.fn().mockResolvedValue({
+			accessToken: 'mock-access-token',
+			idToken: 'mock-id-token',
+		}),
+		clearSession: jest.fn().mockResolvedValue(undefined),
+	};
+
+	credentialsManager = {
+		saveCredentials: jest.fn().mockResolvedValue(undefined),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+	};
+}
+
+export default Auth0;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"axios": "^1.15.2",
 		"react": "19.2.3",
 		"react-native": "0.85.2",
+		"react-native-auth0": "^5.1.0",
 		"react-native-logs": "^5.6.0",
 		"react-native-plaid-link-sdk": "^12.8.0",
 		"react-native-safe-area-context": "5.5.2",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+	"version": 1,
+	"skills": {
+		"auth0-react-native": {
+			"source": "auth0/agent-skills",
+			"sourceType": "github",
+			"skillPath": "plugins/auth0/skills/auth0-react-native/SKILL.md",
+			"computedHash": "79b9acc08925c9f1df61604515eba6a5529c6baf09e38ece2f130ad64f860553"
+		}
+	}
+}

--- a/src/navigation/AppStack/AppStack.test.tsx
+++ b/src/navigation/AppStack/AppStack.test.tsx
@@ -7,6 +7,11 @@ import { createAuthStore } from '@stores/AuthStore';
 import { render } from '@testing-library/react-native';
 import React from 'react';
 
+const mockAuthService = {
+	login: jest.fn().mockResolvedValue('mock-auth0-token'),
+	logout: jest.fn().mockResolvedValue(undefined),
+};
+
 jest.mock('@react-navigation/native-stack', () => {
 	const ReactLib = require('react');
 
@@ -73,7 +78,7 @@ jest.mock('@providers/DatabaseProvider', () => ({
 }));
 
 const renderWithProviders = (ui: React.ReactElement) => {
-	const authStore = createAuthStore(); // Create a real auth store with the storage instance
+	const authStore = createAuthStore(mockAuthService);
 	return render(
 		<DatabaseProvider dbService={{} as any}>
 			<FeatureFlagsProvider>

--- a/src/navigation/AuthStack/AuthStack.test.tsx
+++ b/src/navigation/AuthStack/AuthStack.test.tsx
@@ -4,6 +4,11 @@ import { AuthProvider } from '@providers/AuthProvider';
 import { createAuthStore } from '@stores/AuthStore';
 import { render } from '@testing-library/react-native';
 
+const mockAuthService = {
+	login: jest.fn().mockResolvedValue('mock-auth0-token'),
+	logout: jest.fn().mockResolvedValue(undefined),
+};
+
 // @react-native-async-storage/async-storage
 jest.mock('@react-native-async-storage/async-storage', () => {
 	return {
@@ -20,9 +25,9 @@ jest.mock('@services/StorageService', () => {
 	return {
 		StorageService: {
 			getInstance: jest.fn(() => ({
-				saveItem: jest.fn(),
+				saveItem: jest.fn().mockResolvedValue(undefined),
 				loadItem: jest.fn().mockResolvedValue('mock-token'),
-				clearItem: jest.fn(),
+				clearItem: jest.fn().mockResolvedValue(undefined),
 			})),
 		},
 	};
@@ -30,7 +35,7 @@ jest.mock('@services/StorageService', () => {
 
 // render with auth provider to provide necessary context
 function renderWithAuthProvider(ui: React.ReactElement) {
-	const store = createAuthStore();
+	const store = createAuthStore(mockAuthService);
 	return render(<AuthProvider store={store}>{ui}</AuthProvider>);
 }
 

--- a/src/navigation/RootStack/RootStack.test.tsx
+++ b/src/navigation/RootStack/RootStack.test.tsx
@@ -4,6 +4,11 @@ import { AuthProvider } from '@providers/AuthProvider';
 import { createAuthStore } from '@stores/AuthStore';
 import { render, waitFor } from '@testing-library/react-native';
 
+const mockAuthService = {
+	login: jest.fn().mockResolvedValue('mock-auth0-token'),
+	logout: jest.fn().mockResolvedValue(undefined),
+};
+
 // @op-engineering/op-sqlite
 jest.mock('@op-engineering/op-sqlite', () => ({
 	__esModule: true,
@@ -40,9 +45,9 @@ jest.mock('@navigation/AuthStack/AuthStack', () => {
 
 jest.mock('@services/StorageService', () => {
 	const mockStorage = {
-		saveItem: jest.fn(),
+		saveItem: jest.fn().mockResolvedValue(undefined),
 		loadItem: jest.fn(),
-		clearItem: jest.fn(),
+		clearItem: jest.fn().mockResolvedValue(undefined),
 	};
 
 	return {
@@ -59,7 +64,7 @@ jest.mock('@db/runAIMigrations', () => ({
 }));
 
 function renderWithProviders(ui: React.ReactElement) {
-	const store = createAuthStore();
+	const store = createAuthStore(mockAuthService);
 
 	return render(<AuthProvider store={store}>{ui}</AuthProvider>);
 }

--- a/src/providers/AuthProvider.test.tsx
+++ b/src/providers/AuthProvider.test.tsx
@@ -8,13 +8,18 @@ import * as React from 'react';
 import { AuthProvider, useAuthStore } from './AuthProvider';
 import { StorageService } from '@services/StorageService';
 
+const mockAuthService = {
+	login: jest.fn().mockResolvedValue('mock-auth0-token'),
+	logout: jest.fn().mockResolvedValue(undefined),
+};
+
 jest.mock('@services/StorageService', () => {
 	return {
 		StorageService: {
 			getInstance: jest.fn(() => ({
-				saveItem: jest.fn(),
+				saveItem: jest.fn().mockResolvedValue(undefined),
 				loadItem: jest.fn().mockResolvedValue('saved-token'),
-				clearItem: jest.fn(),
+				clearItem: jest.fn().mockResolvedValue(undefined),
 			})),
 		},
 	};
@@ -30,7 +35,7 @@ jest.mock('@react-native-async-storage/async-storage', () => {
 
 describe('AuthProvider', () => {
 	it('renders children when token is set', () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
 		);
@@ -45,7 +50,7 @@ describe('AuthProvider', () => {
 	});
 
 	it('loads persisted token on mount', async () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 		const mockStorage = StorageService.getInstance('@auth');
 		const actions = store.createActions(jest.fn(), mockStorage);
 
@@ -67,7 +72,7 @@ describe('AuthProvider', () => {
 	});
 
 	it('setToken action updates token in context', () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
@@ -86,8 +91,8 @@ describe('AuthProvider', () => {
 		expect(result.current.token).toBe('new-token');
 	});
 
-	it('logout action resets token to null', () => {
-		const store = createAuthStore();
+	it('logout action resets token to null', async () => {
+		const store = createAuthStore(mockAuthService);
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
@@ -102,8 +107,8 @@ describe('AuthProvider', () => {
 		expect(result.current.token).toBe('token-to-logout');
 
 		// Then logout
-		testAct(() => {
-			result.current.logout();
+		await testAct(async () => {
+			await result.current.logout();
 		});
 		expect(result.current.token).toBeNull();
 	});

--- a/src/screens/LoginScreen/LoginScreen.test.tsx
+++ b/src/screens/LoginScreen/LoginScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import LoginScreen from './LoginScreen';
 import { TestID } from '@enums/TestID';
 import { useAuthStore } from '@providers/AuthProvider';
@@ -9,9 +9,17 @@ jest.mock('@providers/AuthProvider', () => ({
 }));
 
 describe('LoginScreen', () => {
-	it('renders the LoginScreen with welcome text', () => {
-		(useAuthStore as jest.Mock).mockReturnValue(jest.fn());
+	const mockLogin = jest.fn().mockResolvedValue(undefined);
 
+	beforeEach(() => {
+		mockLogin.mockClear();
+		(useAuthStore as jest.Mock).mockImplementation((selector) => {
+			const store = { login: mockLogin };
+			return selector ? selector(store) : store;
+		});
+	});
+
+	it('renders the LoginScreen with welcome text', () => {
 		const { getByTestId, getByText } = render(<LoginScreen />);
 
 		// Check if the LoginScreen container is rendered
@@ -23,17 +31,15 @@ describe('LoginScreen', () => {
 		expect(welcomeText).toBeTruthy();
 	});
 
-	it('calls setToken when the Login button is pressed', () => {
-		const mockSetToken = jest.fn();
-		(useAuthStore as jest.Mock).mockReturnValue(mockSetToken);
-
+	it('calls login when the Login button is pressed', async () => {
 		const { getByText } = render(<LoginScreen />);
 
 		// Press the Login button
 		const loginButton = getByText('Login');
 		fireEvent.press(loginButton);
 
-		// Verify that setToken was called with the correct argument
-		expect(mockSetToken).toHaveBeenCalledWith('authenticated');
+		await waitFor(() => {
+			expect(mockLogin).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -4,17 +4,33 @@ import ThemedScreen from '@components/ThemedScreen/ThemedScreen';
 import { TestID } from '@enums/TestID';
 import { useAuthStore } from '@providers/AuthProvider';
 import { colors, radius, spacing, shadows } from '@theme/tokens';
-import { useMemo } from 'react';
+import { useCallback, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 const LoginScreen = () => {
-	const setToken = useAuthStore((s) => s.setToken);
+	const login = useAuthStore((s) => s.login);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-	const handleLogin = useMemo(() => {
-		return () => {
-			setToken('authenticated');
-		};
-	}, [setToken]);
+	const handleLogin = useCallback(async () => {
+		if (isSubmitting) {
+			return;
+		}
+
+		setErrorMessage(null);
+		setIsSubmitting(true);
+
+		try {
+			await login();
+		} catch (error) {
+			console.error('[LoginScreen] Login failed:', error);
+			setErrorMessage(
+				'Unable to log in right now. Check Auth0 config and try again.',
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	}, [isSubmitting, login]);
 
 	return (
 		<ThemedScreen>
@@ -29,8 +45,13 @@ const LoginScreen = () => {
 					<AppText variant="subtitle" style={styles.subtitle}>
 						Welcome to BudgetAI!
 					</AppText>
+					{errorMessage ? (
+						<AppText style={styles.errorText}>
+							{errorMessage}
+						</AppText>
+					) : null}
 					<PrimaryButton
-						title="Login"
+						title={isSubmitting ? 'Logging in...' : 'Login'}
 						onPress={handleLogin}
 						width="100%"
 					/>
@@ -67,6 +88,10 @@ const styles = StyleSheet.create({
 	},
 	subtitle: {
 		color: colors.neutral.textSecondary,
+		marginBottom: spacing.sm,
+	},
+	errorText: {
+		color: colors.error,
 		marginBottom: spacing.sm,
 	},
 	text: {

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -30,6 +30,12 @@ const DATA: ActionButtonItem[] = [
 		type: 'secondary',
 		testID: 'SettingsOption-go_back',
 	},
+	{
+		id: 'logout',
+		title: 'Logout',
+		type: 'secondary',
+		testID: 'SettingsOption-logout',
+	},
 	// {
 	// 	id: 'clear_transactions',
 	// 	title: 'Clear Transactions',

--- a/src/services/Auth0Service.ts
+++ b/src/services/Auth0Service.ts
@@ -1,0 +1,83 @@
+import Auth0 from 'react-native-auth0';
+
+type Auth0Config = {
+	domain: string;
+	clientId: string;
+};
+
+const AUTH0_CONFIG: Auth0Config = {
+	domain: 'dev-ffksazh23yw1bfhr.us.auth0.com',
+	clientId: 'u3Zwo5Zi5TtXPjU5QXaq6qdoYDPfnAEn',
+};
+
+export type AuthService = {
+	login: () => Promise<string>;
+	logout: () => Promise<void>;
+};
+
+export class Auth0Service implements AuthService {
+	private static instance: Auth0Service | null = null;
+	private readonly client: Auth0;
+	private readonly config: Auth0Config;
+
+	static getInstance(config: Auth0Config = AUTH0_CONFIG): Auth0Service {
+		if (!Auth0Service.instance) {
+			Auth0Service.instance = new Auth0Service(config);
+		}
+
+		return Auth0Service.instance;
+	}
+
+	private constructor(config: Auth0Config) {
+		this.config = config;
+		this.client = new Auth0({
+			domain: config.domain,
+			clientId: config.clientId,
+		});
+	}
+
+	private assertConfigured(): void {
+		if (
+			this.config.domain === 'YOUR_AUTH0_DOMAIN' ||
+			this.config.clientId === 'YOUR_AUTH0_CLIENT_ID'
+		) {
+			throw new Error(
+				'Missing Auth0 configuration. Update AUTH0_CONFIG in src/services/Auth0Service.ts.',
+			);
+		}
+	}
+
+	async login(): Promise<string> {
+		this.assertConfigured();
+
+		const credentials = await this.client.webAuth.authorize({
+			scope: 'openid profile email offline_access',
+		});
+
+		await this.client.credentialsManager.saveCredentials(credentials);
+
+		const token = credentials.accessToken ?? credentials.idToken;
+		if (!token) {
+			throw new Error(
+				'Auth0 login succeeded but no token was returned.',
+			);
+		}
+
+		return token;
+	}
+
+	async logout(): Promise<void> {
+		this.assertConfigured();
+
+		try {
+			await this.client.webAuth.clearSession();
+		} catch (error) {
+			console.warn(
+				'[Auth0Service] clearSession failed; continuing to clear local credentials.',
+				error,
+			);
+		}
+
+		await this.client.credentialsManager.clearCredentials();
+	}
+}

--- a/src/stores/AuthStore.test.ts
+++ b/src/stores/AuthStore.test.ts
@@ -2,6 +2,11 @@ import { createAuthStore } from '@stores/AuthStore';
 import { StorageService } from '@services/StorageService';
 import { act } from '@testing-library/react-native';
 
+const mockAuthService = {
+	login: jest.fn().mockResolvedValue('auth0-token'),
+	logout: jest.fn().mockResolvedValue(undefined),
+};
+
 // @react-native-async-storage/async-storage
 jest.mock('@react-native-async-storage/async-storage', () => {
 	return {
@@ -17,12 +22,12 @@ describe('AuthStore', () => {
 	const storage = StorageService.getInstance('@auth');
 
 	it('initializes with null token', () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 		expect(store.getInitialState().token).toBeNull();
 	});
 
 	it('sets token correctly', () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 		const state = store.reducer(store.getInitialState(), {
 			type: 'SET_TOKEN',
 			token: 'test-token',
@@ -31,7 +36,7 @@ describe('AuthStore', () => {
 	});
 
 	it('logs out correctly by resetting token to null', () => {
-		const store = createAuthStore();
+		const store = createAuthStore(mockAuthService);
 		const state = store.reducer(
 			{ token: 'existing-token' },
 			{
@@ -41,19 +46,27 @@ describe('AuthStore', () => {
 		expect(state.token).toBeNull();
 	});
 
-	it('creates typed actions that dispatch reducer events', () => {
-		const store = createAuthStore();
+	it('creates typed actions that dispatch reducer events', async () => {
+		const store = createAuthStore(mockAuthService);
 		const dispatch = jest.fn();
 		const actions = store.createActions(dispatch, storage);
 
 		act(() => {
 			actions.setToken('token-from-action');
-			actions.logout();
+		});
+
+		await act(async () => {
+			await actions.login();
+			await actions.logout();
 		});
 
 		expect(dispatch).toHaveBeenCalledWith({
 			type: 'SET_TOKEN',
 			token: 'token-from-action',
+		});
+		expect(dispatch).toHaveBeenCalledWith({
+			type: 'SET_TOKEN',
+			token: 'auth0-token',
 		});
 		expect(dispatch).toHaveBeenCalledWith({ type: 'LOGOUT' });
 	});

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -1,4 +1,5 @@
 import { StorageKey } from '@enums/StorageKey';
+import { Auth0Service, type AuthService } from '@services/Auth0Service';
 import type { StorageService } from '@services/StorageService';
 import type { Dispatch } from 'react';
 
@@ -8,7 +9,8 @@ export type AuthState = {
 
 export type AuthActions = {
 	setToken: (newToken: string | null) => void;
-	logout: () => void;
+	login: () => Promise<void>;
+	logout: () => Promise<void>;
 };
 
 export type AuthStore = AuthState & AuthActions;
@@ -26,7 +28,9 @@ export type AuthStoreFactory = {
 	) => AuthActions;
 };
 
-export const createAuthStore = (): AuthStoreFactory => {
+export const createAuthStore = (
+	authService: AuthService = Auth0Service.getInstance(),
+): AuthStoreFactory => {
 	const initialState: AuthState = {
 		token: null,
 	};
@@ -51,15 +55,40 @@ export const createAuthStore = (): AuthStoreFactory => {
 		): AuthActions {
 			function setToken(token: string | null) {
 				dispatch({ type: 'SET_TOKEN', token });
-				storage.saveItem(token, StorageKey.AuthToken);
+				async function persistToken(): Promise<void> {
+					try {
+						await storage.saveItem(token, StorageKey.AuthToken);
+					} catch (error) {
+						console.error(
+							'[AuthStore] Failed to persist auth token:',
+							error,
+						);
+					}
+				}
+
+				persistToken();
 			}
 
-			function logout() {
+			async function login() {
+				const token = await authService.login();
+				dispatch({ type: 'SET_TOKEN', token });
+				await storage.saveItem(token, StorageKey.AuthToken);
+			}
+
+			async function logout() {
+				try {
+					await authService.logout();
+				} catch (error) {
+					console.error(
+						'[AuthStore] Remote logout failed. Clearing local auth state anyway:',
+						error,
+					);
+				}
 				dispatch({ type: 'LOGOUT' });
-				storage.clearItem(StorageKey.AuthToken);
+				await storage.clearItem(StorageKey.AuthToken);
 			}
 
-			return { setToken, logout };
+			return { setToken, login, logout };
 		},
 	};
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,28 @@ __metadata:
   version: 9
   cacheKey: 10c0
 
+"@auth0/auth0-auth-js@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@auth0/auth0-auth-js@npm:1.6.0"
+  dependencies:
+    jose: "npm:^6.0.8"
+    openid-client: "npm:^6.8.0"
+  checksum: 10c0/0f5672ea77045d1172dac8a2571f1a7111045677191fa6105c0458a720fab3db385384b302535a6694c16dfe82ef0e9a3510d2113d5c35ca0f5ecd1bb1d96c05
+  languageName: node
+  linkType: hard
+
+"@auth0/auth0-spa-js@npm:2.18.2":
+  version: 2.18.2
+  resolution: "@auth0/auth0-spa-js@npm:2.18.2"
+  dependencies:
+    "@auth0/auth0-auth-js": "npm:1.6.0"
+    browser-tabs-lock: "npm:1.3.0"
+    dpop: "npm:2.1.1"
+    es-cookie: "npm:1.3.2"
+  checksum: 10c0/b100778d4896ceb9cb88684f13c5ab0d45cf71430cbb4184530da32aaa1081b91ab6fa4621c56b184d8b488be4adc2570ac1ae5c0dd7d89f0e4a8f6a2616eae9
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/code-frame@npm:7.29.0"
@@ -3424,6 +3446,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-64@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "base-64@npm:1.0.0"
+  checksum: 10c0/d886cb3236cee0bed9f7075675748b59b32fad623ddb8ce1793c790306aa0f76a03238cad4b3fb398abda6527ce08a5588388533a4ccade0b97e82b9da660e28
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -3508,6 +3537,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-tabs-lock@npm:1.3.0":
+  version: 1.3.0
+  resolution: "browser-tabs-lock@npm:1.3.0"
+  dependencies:
+    lodash: "npm:>=4.17.21"
+  checksum: 10c0/b1f9cbd221725cf3228daf42360ea6a97f69b29e0475ef734bc5a6bd5c27b61f99db716c49808988a1c735d828207dcaa3a8802e605d0195538fbf9e25d1753b
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
@@ -3563,6 +3601,7 @@ __metadata:
     prettier: "npm:2.8.8"
     react: "npm:19.2.3"
     react-native: "npm:0.85.2"
+    react-native-auth0: "npm:^5.1.0"
     react-native-logs: "npm:^5.6.0"
     react-native-plaid-link-sdk: "npm:^12.8.0"
     react-native-safe-area-context: "npm:5.5.2"
@@ -4233,6 +4272,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dpop@npm:2.1.1":
+  version: 2.1.1
+  resolution: "dpop@npm:2.1.1"
+  checksum: 10c0/e46dfd62325dd63372a17492c1867f79cdaf235645d32b87c3be8a09d4c7b03b8b44efec26688ba19e8279c77497a08deb302a9a4704b432795efd1163519611
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -4389,6 +4435,13 @@ __metadata:
     unbox-primitive: "npm:^1.1.0"
     which-typed-array: "npm:^1.1.19"
   checksum: 10c0/67a5bf21ef5c7d775e6f6131a836323900b4d87194cf544394ac68fe31c57fa53828b978af4a4f551ef307f83a2f910a16b6b982760ad3ddc3dc471f98d5fd1b
+  languageName: node
+  linkType: hard
+
+"es-cookie@npm:1.3.2":
+  version: 1.3.2
+  resolution: "es-cookie@npm:1.3.2"
+  checksum: 10c0/26eb6e06b25b5569d8763fcb23b5335a5098e354b0a9a7bc5122e8c8705003307187a165ddaeda5cff08fa4cc8e1675dbddd5709279fb27cfa8875514dc3eccb
   languageName: node
   linkType: hard
 
@@ -6468,6 +6521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.0.8, jose@npm:^6.2.2":
+  version: 6.2.3
+  resolution: "jose@npm:6.2.3"
+  checksum: 10c0/aa91bccba22cc84d86308f833749bcb0b00441e35c24e0ac79abeac5f76dc62d47bdef9c1da6a0c609f5da6478595f52b252085888b89dbdb163861e40ea4188
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -6572,6 +6632,13 @@ __metadata:
     object.assign: "npm:^4.1.4"
     object.values: "npm:^1.1.6"
   checksum: 10c0/a32679e9cb55469cb6d8bbc863f7d631b2c98b7fc7bf172629261751a6e7bc8da6ae374ddb74d5fbd8b06cf0eb4572287b259813d92b36e384024ed35e4c13e1
+  languageName: node
+  linkType: hard
+
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
   languageName: node
   linkType: hard
 
@@ -6684,7 +6751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
+"lodash@npm:>=4.17.21, lodash@npm:^4.17.21":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
@@ -7318,6 +7385,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oauth4webapi@npm:^3.8.5":
+  version: 3.8.6
+  resolution: "oauth4webapi@npm:3.8.6"
+  checksum: 10c0/479810716702c5616e4a0eb80d4f1c264a6a2b63b04061a62a59375e195d2726e947507ede98e41ee3f9ca800f159621ea371c36f5c4346d015b6ec03e477440
+  languageName: node
+  linkType: hard
+
 "ob1@npm:0.84.3":
   version: 0.84.3
   resolution: "ob1@npm:0.84.3"
@@ -7457,6 +7531,16 @@ __metadata:
     is-docker: "npm:^2.0.0"
     is-wsl: "npm:^2.1.1"
   checksum: 10c0/77573a6a68f7364f3a19a4c80492712720746b63680ee304555112605ead196afe91052bd3c3d165efdf4e9d04d255e87de0d0a77acec11ef47fd5261251813f
+  languageName: node
+  linkType: hard
+
+"openid-client@npm:^6.8.0":
+  version: 6.8.4
+  resolution: "openid-client@npm:6.8.4"
+  dependencies:
+    jose: "npm:^6.2.2"
+    oauth4webapi: "npm:^3.8.5"
+  checksum: 10c0/bb062df77d48368f99f776f26d94e11053da80b89d2baeea9f069b7a2b359ef5dc10e0c9b0f9a90fb361eded7ff02dba3f5419b8909ec3f0c379d09807824c49
   languageName: node
   linkType: hard
 
@@ -7762,6 +7846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "punycode@npm:1.4.1"
+  checksum: 10c0/354b743320518aef36f77013be6e15da4db24c2b4f62c5f1eb0529a6ed02fbaf1cb52925785f6ab85a962f2b590d9cd5ad730b70da72b5f180e2556b8bd3ca08
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -7776,7 +7867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.14.1":
+"qs@npm:^6.12.3, qs@npm:^6.14.1":
   version: 6.15.1
   resolution: "qs@npm:6.15.1"
   dependencies:
@@ -7878,6 +7969,24 @@ __metadata:
   version: 19.2.5
   resolution: "react-is@npm:19.2.5"
   checksum: 10c0/58c28ab2f7f868f9836c728fa164a16dcf20246ab84a3ae6a09e617b0e4d9bbb3acdddfdc40452f0134d27b121d3359227602a050c0be554cb20069cb52a67f4
+  languageName: node
+  linkType: hard
+
+"react-native-auth0@npm:^5.1.0":
+  version: 5.5.1
+  resolution: "react-native-auth0@npm:5.5.1"
+  dependencies:
+    "@auth0/auth0-spa-js": "npm:2.18.2"
+    base-64: "npm:^1.0.0"
+    jwt-decode: "npm:^4.0.0"
+    url: "npm:^0.11.4"
+  peerDependencies:
+    react: ">=19.0.0"
+    react-native: ">=0.78.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
+  checksum: 10c0/0aa2b96dd598890cfa1559f9336f500775f9622327360cb24bfbbfdec0f8bf98c0fe4f14268574e1586dc48ed862db1a01bc8ab97c7bd4ff4984d24a1017a94f
   languageName: node
   linkType: hard
 
@@ -9196,6 +9305,16 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.4":
+  version: 0.11.4
+  resolution: "url@npm:0.11.4"
+  dependencies:
+    punycode: "npm:^1.4.1"
+    qs: "npm:^6.12.3"
+  checksum: 10c0/cc93405ae4a9b97a2aa60ca67f1cb1481c0221cb4725a7341d149be5e2f9cfda26fd432d64dbbec693d16593b68b8a46aad8e5eab21f814932134c9d8620c662
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces comprehensive integration of Auth0 authentication for React Native and Expo mobile apps, including both implementation and documentation. The main changes add support for secure authentication flows, platform-specific configuration, and developer guidance for setup, testing, and troubleshooting. The update also ensures proper mocking for Auth0 in tests and enhances the documentation and configuration files for a smooth developer experience.

**Auth0 React Native Integration**

* Added the `react-native-auth0` dependency to the project for mobile authentication support.
* Introduced a dedicated skill for Auth0 React Native in `.agents/skills/auth0-react-native/SKILL.md`, providing a thorough quickstart, setup, usage patterns, troubleshooting, and references.
* Supplemented with detailed guides for setup (`references/setup.md`), usage patterns (`references/patterns.md`), and API/testing/troubleshooting (`references/api.md`). [[1]](diffhunk://#diff-840b060f8a9b40d48dbc6ee2993e90a8f90234ae0126ea400f6d5b86405c7c4bR1-R149) [[2]](diffhunk://#diff-0424a914045217acb18fcd8bc15c8fcbe8a213b56b8c4ea26bbd9f15b6a729fbR1-R196) [[3]](diffhunk://#diff-b07415e3591eddc91993430bbac073d9ec01e62d1e68d290eb50758f6ae4a6ebR1-R63)
* Registered the new skill in `skills-lock.json` for skill management and reproducibility.

**Platform-Specific Configuration**

* Updated `android/app/build.gradle` and `android/app/src/main/AndroidManifest.xml` to add Auth0 domain placeholders and deep linking intent filters for Android authentication callbacks. [[1]](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9R87-R89) [[2]](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR26-R38)
* Modified `ios/BudgetAI/Info.plist` to register the Auth0 URL scheme for iOS deep linking.
* Added step-by-step Auth0 setup instructions to the project `README.md` for easier onboarding.

**Testing and Mocking Enhancements**

* Added a Jest mock for `react-native-auth0` in `jest/mocks/reactNativeAuth0.ts` and configured Jest to use it, enabling reliable test runs without real Auth0 calls. [[1]](diffhunk://#diff-f5ee4b1d3c10100b36fe6421201c44c99e07cc74d188fb8bad4f0c8537c54ad9R1-R16) [[2]](diffhunk://#diff-860bd1f15d1e0bafcfc6f62560524f588e6d6bf56d4ab1b0f6f8146461558730R115)
* Updated test utilities in `src/navigation/AppStack/AppStack.test.tsx` to use a mock Auth0 service, ensuring authentication logic is testable and decoupled from the real provider. [[1]](diffhunk://#diff-e3260b6168b7ae3bc3689b00d8afb5eb668a8679e307d732cbccdffbd629e3ccR10-R14) [[2]](diffhunk://#diff-e3260b6168b7ae3bc3689b00d8afb5eb668a8679e307d732cbccdffbd629e3ccL76-R81)

These changes collectively provide robust, secure, and well-documented Auth0 authentication for the mobile application, along with thorough support for testing and developer onboarding.