### PR TITLE
fix: fix base64

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -59,7 +59,13 @@ jobs:
                   CERTIFICATE_PATH="$RUNNER_TEMP/ios_distribution.p12"
                   KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
 
-                  echo "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+                  printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+
+                  if ! openssl pkcs12 -in "$CERTIFICATE_PATH" -nokeys -passin "pass:$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" >/dev/null 2>&1 && \
+                     ! openssl pkcs12 -legacy -in "$CERTIFICATE_PATH" -nokeys -passin "pass:$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" >/dev/null 2>&1; then
+                      echo "::error::IOS_DISTRIBUTION_CERTIFICATE_BASE64 must be a base64-encoded .p12 file, and IOS_DISTRIBUTION_CERTIFICATE_PASSWORD must match the .p12 export password."
+                      exit 1
+                  fi
 
                   security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
                   security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"


### PR DESCRIPTION
This pull request improves the robustness of the iOS distribution certificate handling in the TestFlight workflow by adding validation for the certificate and its password. The most important change is the introduction of a check to ensure that the provided base64-encoded certificate and password are valid before proceeding with the signing process.

Enhancements to certificate validation and workflow reliability:

* Added a validation step to check that the decoded `IOS_DISTRIBUTION_CERTIFICATE_BASE64` is a valid `.p12` file and that the `IOS_DISTRIBUTION_CERTIFICATE_PASSWORD` matches the export password. If validation fails, the workflow will output an error and exit early.
* Replaced `echo` with `printf '%s'` when decoding the base64 certificate to avoid potential issues with trailing newlines or formatting.