### PR TITLE
fix: change upload sdk

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -23,12 +23,22 @@ env:
 jobs:
     upload-testflight:
         name: Build and Upload to TestFlight
-        runs-on: macos-latest
+        runs-on: macos-26
         timeout-minutes: 60
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+
+            - name: Set up Xcode
+              uses: maxim-lobanov/setup-xcode@v1
+              with:
+                  xcode-version: latest-stable
+
+            - name: Print Xcode version
+              run: |
+                  xcodebuild -version
+                  xcodebuild -showsdks
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -83,7 +93,12 @@ jobs:
                   PROFILE_PATH="$RUNNER_TEMP/app_store.mobileprovision"
                   PROFILE_PLIST="$RUNNER_TEMP/app_store_profile.plist"
 
-                  echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+                  if [ -z "$IOS_PROVISIONING_PROFILE_BASE64" ]; then
+                      echo "::error::IOS_PROVISIONING_PROFILE_BASE64 is empty. Add a base64-encoded App Store provisioning profile as a GitHub Actions secret."
+                      exit 1
+                  fi
+
+                  printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
                   security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
 
                   PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" "$PROFILE_PLIST")

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ env.json
 AuthKey_K2NX4TG994_P8_base64.txt
 
 ios_distribution.p12
+
+Budget_AI_Provisioning_Profile.mobileprovision


### PR DESCRIPTION
This pull request updates the TestFlight GitHub Actions workflow to improve reliability and error handling during the build and upload process. The most important changes are grouped below:

**Environment and Tooling Updates:**

* Changed the GitHub Actions runner from `macos-latest` to `macos-26` to ensure a consistent and up-to-date macOS environment.
* Added a dedicated step to set up Xcode using the `maxim-lobanov/setup-xcode@v1` action and ensured the latest stable Xcode version is used.
* Added a step to print the Xcode version and available SDKs for easier debugging and transparency in the workflow logs.

**Provisioning Profile Handling Improvements:**

* Added a check to ensure the `IOS_PROVISIONING_PROFILE_BASE64` secret is set. If it is missing, the workflow fails early with a clear error message, preventing confusing downstream errors.
* Changed the decoding of the provisioning profile to use `printf` instead of `echo` for better handling of the base64 string.