### PR TITLE
feat: added ownerId

### DIFF
--- a/ios/BudgetAI.xcodeproj/project.pbxproj
+++ b/ios/BudgetAI.xcodeproj/project.pbxproj
@@ -191,13 +191,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BudgetAI/Pods-BudgetAI-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BudgetAI/Pods-BudgetAI-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -234,13 +230,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BudgetAI/Pods-BudgetAI-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BudgetAI/Pods-BudgetAI-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/src/db/runAIMigrations.ts
+++ b/src/db/runAIMigrations.ts
@@ -110,11 +110,12 @@ export async function runAIMigrations(db: DB) {
       CREATE TABLE IF NOT EXISTS categories (
         id TEXT PRIMARY KEY,
         owner_id TEXT,
-        name TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
         color TEXT,
         icon TEXT,
         created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
+        updated_at TEXT NOT NULL,
+        UNIQUE(owner_id, name)
       );
     `);
 
@@ -208,7 +209,9 @@ export async function runAIMigrations(db: DB) {
 	}
 
 	// Post-migration checks for categories table
-	const categoryColumns = await db.execute('PRAGMA table_info(categories)');
+	const categoryColumns = await db.execute(
+		'PRAGMA table_info(categories)',
+	);
 	const hasCategoryColumn = (columnName: string) =>
 		categoryColumns.rows.some((row) => String(row.name) === columnName);
 
@@ -229,4 +232,107 @@ export async function runAIMigrations(db: DB) {
     CREATE INDEX IF NOT EXISTS idx_transactions_account_date
     ON transactions(account_id, date, created_at)
   `);
+
+	await db.execute(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_owner_name
+    ON categories(owner_id, name)
+  `);
+
+	const categoryIndexes = await db.execute(
+		'PRAGMA index_list(categories)',
+	);
+	let hasOwnerNameUniqueConstraint = false;
+	let hasLegacyGlobalNameUniqueConstraint = false;
+
+	for (const indexRow of categoryIndexes.rows) {
+		const isUnique = Number(indexRow.unique) === 1;
+		if (!isUnique) {
+			continue;
+		}
+
+		const indexName = String(indexRow.name ?? '');
+		if (!indexName) {
+			continue;
+		}
+
+		const indexInfo = await db.execute(
+			`PRAGMA index_info('${indexName.replace(/'/g, "''")}')`,
+		);
+		const columnNames = indexInfo.rows
+			.sort((a, b) => Number(a.seqno) - Number(b.seqno))
+			.map((row) => String(row.name));
+
+		if (
+			columnNames.length === 2 &&
+			columnNames[0] === 'owner_id' &&
+			columnNames[1] === 'name'
+		) {
+			hasOwnerNameUniqueConstraint = true;
+		}
+
+		if (columnNames.length === 1 && columnNames[0] === 'name') {
+			hasLegacyGlobalNameUniqueConstraint = true;
+		}
+	}
+
+	// Migrate legacy categories schema from UNIQUE(name) to UNIQUE(owner_id, name).
+	if (
+		hasLegacyGlobalNameUniqueConstraint ||
+		!hasOwnerNameUniqueConstraint
+	) {
+		await db.execute('PRAGMA foreign_keys = OFF');
+
+		await db.transaction(async (tx) => {
+			await tx.execute(`
+        CREATE TABLE categories_new (
+          id TEXT PRIMARY KEY,
+          owner_id TEXT,
+          name TEXT NOT NULL,
+          color TEXT,
+          icon TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          UNIQUE(owner_id, name)
+        )
+      `);
+
+			await tx.execute(`
+        INSERT INTO categories_new (
+          id,
+          owner_id,
+          name,
+          color,
+          icon,
+          created_at,
+          updated_at
+        )
+        SELECT
+          id,
+          owner_id,
+          name,
+          color,
+          icon,
+          created_at,
+          updated_at
+        FROM categories
+      `);
+
+			await tx.execute('DROP TABLE categories');
+			await tx.execute(
+				'ALTER TABLE categories_new RENAME TO categories',
+			);
+
+			await tx.execute(`
+        CREATE INDEX IF NOT EXISTS idx_categories_name
+        ON categories(name)
+      `);
+
+			await tx.execute(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_categories_owner_name
+        ON categories(owner_id, name)
+      `);
+		});
+
+		await db.execute('PRAGMA foreign_keys = ON');
+	}
 }

--- a/src/db/runAIMigrations.ts
+++ b/src/db/runAIMigrations.ts
@@ -6,6 +6,7 @@ export async function runAIMigrations(db: DB) {
 		await tx.execute(`
       CREATE TABLE IF NOT EXISTS accounts (
         id TEXT PRIMARY KEY,
+        owner_id TEXT,
         name TEXT NOT NULL,
         account_type TEXT NOT NULL,
         currency TEXT NOT NULL DEFAULT 'USD',
@@ -87,6 +88,7 @@ export async function runAIMigrations(db: DB) {
 		await tx.execute(`
       CREATE TABLE IF NOT EXISTS transactions (
         id TEXT PRIMARY KEY,
+        owner_id TEXT,
         account_id TEXT,
         amount REAL NOT NULL,
         merchant TEXT,
@@ -107,6 +109,7 @@ export async function runAIMigrations(db: DB) {
 		await tx.execute(`
       CREATE TABLE IF NOT EXISTS categories (
         id TEXT PRIMARY KEY,
+        owner_id TEXT,
         name TEXT NOT NULL UNIQUE,
         color TEXT,
         icon TEXT,
@@ -119,6 +122,7 @@ export async function runAIMigrations(db: DB) {
 		await tx.execute(`
       CREATE TABLE IF NOT EXISTS budgets (
         id TEXT PRIMARY KEY,
+        owner_id TEXT,
         name TEXT NOT NULL,
         amount REAL NOT NULL,
         category_id TEXT,
@@ -172,6 +176,12 @@ export async function runAIMigrations(db: DB) {
 			(row) => String(row.name) === columnName,
 		);
 
+	if (!hasTransactionColumn('owner_id')) {
+		await db.execute(
+			'ALTER TABLE transactions ADD COLUMN owner_id TEXT',
+		);
+	}
+
 	if (!hasTransactionColumn('account_id')) {
 		await db.execute(
 			'ALTER TABLE transactions ADD COLUMN account_id TEXT',
@@ -186,6 +196,33 @@ export async function runAIMigrations(db: DB) {
 
 	if (!hasTransactionColumn('source')) {
 		await db.execute('ALTER TABLE transactions ADD COLUMN source TEXT');
+	}
+
+	// Post-migration checks for accounts table
+	const accountColumns = await db.execute('PRAGMA table_info(accounts)');
+	const hasAccountColumn = (columnName: string) =>
+		accountColumns.rows.some((row) => String(row.name) === columnName);
+
+	if (!hasAccountColumn('owner_id')) {
+		await db.execute('ALTER TABLE accounts ADD COLUMN owner_id TEXT');
+	}
+
+	// Post-migration checks for categories table
+	const categoryColumns = await db.execute('PRAGMA table_info(categories)');
+	const hasCategoryColumn = (columnName: string) =>
+		categoryColumns.rows.some((row) => String(row.name) === columnName);
+
+	if (!hasCategoryColumn('owner_id')) {
+		await db.execute('ALTER TABLE categories ADD COLUMN owner_id TEXT');
+	}
+
+	// Post-migration checks for budgets table
+	const budgetColumns = await db.execute('PRAGMA table_info(budgets)');
+	const hasBudgetColumn = (columnName: string) =>
+		budgetColumns.rows.some((row) => String(row.name) === columnName);
+
+	if (!hasBudgetColumn('owner_id')) {
+		await db.execute('ALTER TABLE budgets ADD COLUMN owner_id TEXT');
 	}
 
 	await db.execute(`

--- a/src/enums/StorageKey.ts
+++ b/src/enums/StorageKey.ts
@@ -1,4 +1,5 @@
 export enum StorageKey {
 	AuthToken = 'auth_token',
+	AuthUserId = 'auth_user_id',
 	ThemeMode = 'theme_mode',
 }

--- a/src/hooks/useBackfillOwnerId.test.ts
+++ b/src/hooks/useBackfillOwnerId.test.ts
@@ -1,0 +1,115 @@
+import { useBackfillOwnerId } from '@hooks/useBackfillOwnerId';
+import { executeTransaction } from '@db/executeTransaction';
+import { notifyTableChanged } from '@db/databaseChangeNotifier';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { DB } from '@op-engineering/op-sqlite';
+
+jest.mock('@db/executeTransaction', () => ({
+	executeTransaction: jest.fn(),
+}));
+
+jest.mock('@db/databaseChangeNotifier', () => ({
+	notifyTableChanged: jest.fn(),
+}));
+
+const mockExecuteTransaction = executeTransaction as jest.MockedFunction<
+	typeof executeTransaction
+>;
+const mockNotifyTableChanged = notifyTableChanged as jest.MockedFunction<
+	typeof notifyTableChanged
+>;
+
+describe('useBackfillOwnerId', () => {
+	const db = {} as DB;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockExecuteTransaction.mockResolvedValue(undefined);
+	});
+
+	it('does not backfill when userId is null', async () => {
+		renderHook(() => useBackfillOwnerId(db, null));
+
+		await waitFor(() => {
+			expect(mockExecuteTransaction).not.toHaveBeenCalled();
+		});
+	});
+
+	it('backfills once for the current user and emits table notifications', async () => {
+		const { rerender } = renderHook(
+			({ userId }) => useBackfillOwnerId(db, userId),
+			{
+				initialProps: { userId: 'auth0|user_1' as string | null },
+			},
+		);
+
+		await waitFor(() => {
+			expect(mockExecuteTransaction).toHaveBeenCalledTimes(1);
+		});
+
+		expect(mockExecuteTransaction).toHaveBeenCalledWith(db, [
+			{
+				sql: 'UPDATE transactions SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_1'],
+			},
+			{
+				sql: 'UPDATE accounts SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_1'],
+			},
+			{
+				sql: 'UPDATE categories SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_1'],
+			},
+			{
+				sql: 'UPDATE budgets SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_1'],
+			},
+		]);
+
+		expect(mockNotifyTableChanged).toHaveBeenCalledTimes(4);
+
+		rerender({ userId: 'auth0|user_1' });
+
+		await waitFor(() => {
+			expect(mockExecuteTransaction).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	it('backfills again when the authenticated user changes', async () => {
+		const { rerender } = renderHook(
+			({ userId }) => useBackfillOwnerId(db, userId),
+			{
+				initialProps: { userId: 'auth0|user_1' as string | null },
+			},
+		);
+
+		await waitFor(() => {
+			expect(mockExecuteTransaction).toHaveBeenCalledTimes(1);
+		});
+
+		rerender({ userId: 'auth0|user_2' });
+
+		await waitFor(() => {
+			expect(mockExecuteTransaction).toHaveBeenCalledTimes(2);
+		});
+
+		expect(mockExecuteTransaction.mock.calls[1]?.[1]).toEqual([
+			{
+				sql: 'UPDATE transactions SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_2'],
+			},
+			{
+				sql: 'UPDATE accounts SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_2'],
+			},
+			{
+				sql: 'UPDATE categories SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_2'],
+			},
+			{
+				sql: 'UPDATE budgets SET owner_id = ? WHERE owner_id IS NULL',
+				args: ['auth0|user_2'],
+			},
+		]);
+	});
+});

--- a/src/hooks/useBackfillOwnerId.ts
+++ b/src/hooks/useBackfillOwnerId.ts
@@ -52,7 +52,10 @@ export function useBackfillOwnerId(db: DB, userId: string | null): void {
 				notifyTableChanged('categories');
 				notifyTableChanged('budgets');
 			} catch (error) {
-				console.error('[useBackfillOwnerId] Failed to backfill owner_id', error);
+				console.error(
+					'[useBackfillOwnerId] Failed to backfill owner_id',
+					error,
+				);
 			}
 		};
 

--- a/src/hooks/useBackfillOwnerId.ts
+++ b/src/hooks/useBackfillOwnerId.ts
@@ -1,0 +1,65 @@
+import { notifyTableChanged } from '@db/databaseChangeNotifier';
+import { executeTransaction } from '@db/executeTransaction';
+import { DB } from '@op-engineering/op-sqlite';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Backfills owner_id for pre-existing local records.
+ * Safe to run multiple times because it only touches NULL owner_id values.
+ */
+export function useBackfillOwnerId(db: DB, userId: string | null): void {
+	const lastBackfilledUserId = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!userId) {
+			return;
+		}
+
+		if (lastBackfilledUserId.current === userId) {
+			return;
+		}
+
+		let isCancelled = false;
+
+		const runBackfill = async () => {
+			try {
+				await executeTransaction(db, [
+					{
+						sql: 'UPDATE transactions SET owner_id = ? WHERE owner_id IS NULL',
+						args: [userId],
+					},
+					{
+						sql: 'UPDATE accounts SET owner_id = ? WHERE owner_id IS NULL',
+						args: [userId],
+					},
+					{
+						sql: 'UPDATE categories SET owner_id = ? WHERE owner_id IS NULL',
+						args: [userId],
+					},
+					{
+						sql: 'UPDATE budgets SET owner_id = ? WHERE owner_id IS NULL',
+						args: [userId],
+					},
+				]);
+
+				if (isCancelled) {
+					return;
+				}
+
+				lastBackfilledUserId.current = userId;
+				notifyTableChanged('transactions');
+				notifyTableChanged('accounts');
+				notifyTableChanged('categories');
+				notifyTableChanged('budgets');
+			} catch (error) {
+				console.error('[useBackfillOwnerId] Failed to backfill owner_id', error);
+			}
+		};
+
+		runBackfill();
+
+		return () => {
+			isCancelled = true;
+		};
+	}, [db, userId]);
+}

--- a/src/hooks/useDevDataReset.ts
+++ b/src/hooks/useDevDataReset.ts
@@ -42,7 +42,7 @@ export const useDevDataReset = (db: DB, api: ApiClient) => {
 		DevSettings.addMenuItem('Clear Accounts (Dev)', async () => {
 			try {
 				await new ClearAccounts(
-					new AccountRepository(db),
+					new AccountRepository(db, null, api),
 				).execute();
 				dbLog.debug('Dev menu cleared accounts');
 			} catch (error) {
@@ -55,7 +55,9 @@ export const useDevDataReset = (db: DB, api: ApiClient) => {
 
 		DevSettings.addMenuItem('Clear Budgets (Dev)', async () => {
 			try {
-				await new ClearBudgets(new BudgetRepository(db)).execute();
+				await new ClearBudgets(
+					new BudgetRepository(db, null, api),
+				).execute();
 				dbLog.debug('Dev menu cleared budgets');
 			} catch (error) {
 				dbLog.error('Failed to clear budgets from dev menu', error);
@@ -65,7 +67,7 @@ export const useDevDataReset = (db: DB, api: ApiClient) => {
 		DevSettings.addMenuItem('Clear Categories (Dev)', async () => {
 			try {
 				await new ClearCategories(
-					new CategoryRepository(db),
+					new CategoryRepository(db, null, api),
 				).execute();
 				dbLog.debug('Dev menu cleared categories');
 			} catch (error) {

--- a/src/hooks/useDevDataReset.ts
+++ b/src/hooks/useDevDataReset.ts
@@ -3,6 +3,7 @@ import { AccountRepository } from '@repositories/AccountRepository';
 import { BudgetRepository } from '@repositories/BudgetRepository';
 import { CategoryRepository } from '@repositories/CategoryRepository';
 import { TransactionRepository } from '@repositories/TransactionRepository';
+import { ApiClient } from '@services/ApiClient';
 import { ClearAccounts } from '@usecases/clearAccounts';
 import { ClearBudgets } from '@usecases/clearBudgets';
 import { ClearCategories } from '@usecases/clearCategories';
@@ -14,7 +15,7 @@ import { DevSettings } from 'react-native';
 /**
  * Dev-only helper for quickly clearing local financial tables.
  */
-export const useDevDataReset = (db: DB) => {
+export const useDevDataReset = (db: DB, api: ApiClient) => {
 	const hasRegisteredMenuItems = useRef(false);
 
 	useEffect(() => {
@@ -27,7 +28,7 @@ export const useDevDataReset = (db: DB) => {
 		DevSettings.addMenuItem('Clear Transactions (Dev)', async () => {
 			try {
 				await new ClearTransactions(
-					new TransactionRepository(db),
+					new TransactionRepository(db, null, api),
 				).execute();
 				dbLog.debug('Dev menu cleared transactions');
 			} catch (error) {
@@ -74,5 +75,5 @@ export const useDevDataReset = (db: DB) => {
 				);
 			}
 		});
-	}, [db]);
+	}, [api, db]);
 };

--- a/src/hooks/useReactiveAccounts.ts
+++ b/src/hooks/useReactiveAccounts.ts
@@ -31,7 +31,10 @@ export function useReactiveAccounts(
 		const fetchAccounts = async () => {
 			try {
 				const query = ownerId
-					? `${ACCOUNTS_QUERY.trim().replace('ORDER BY name ASC', 'WHERE owner_id = ? ORDER BY name ASC')}`
+					? `${ACCOUNTS_QUERY.trim().replace(
+							'ORDER BY name ASC',
+							'WHERE owner_id = ? ORDER BY name ASC',
+					  )}`
 					: ACCOUNTS_QUERY;
 				const result = ownerId
 					? await db.execute(query, [ownerId])
@@ -60,7 +63,10 @@ export function useReactiveAccounts(
 		}
 
 		const query = ownerId
-			? `${ACCOUNTS_QUERY.trim().replace('ORDER BY name ASC', 'WHERE owner_id = ? ORDER BY name ASC')}`
+			? `${ACCOUNTS_QUERY.trim().replace(
+					'ORDER BY name ASC',
+					'WHERE owner_id = ? ORDER BY name ASC',
+			  )}`
 			: ACCOUNTS_QUERY;
 		const argumentsArray = ownerId ? [ownerId] : [];
 

--- a/src/hooks/useReactiveAccounts.ts
+++ b/src/hooks/useReactiveAccounts.ts
@@ -15,7 +15,10 @@ const ACCOUNTS_QUERY = `
 	ORDER BY name ASC
 `;
 
-export function useReactiveAccounts(db: DB | null): Account[] {
+export function useReactiveAccounts(
+	db: DB | null,
+	ownerId: string | null = null,
+): Account[] {
 	const [accounts, setAccounts] = useState<Account[]>([]);
 	const [updateTrigger, setUpdateTrigger] = useState(0);
 
@@ -27,7 +30,12 @@ export function useReactiveAccounts(db: DB | null): Account[] {
 
 		const fetchAccounts = async () => {
 			try {
-				const result = await db.execute(ACCOUNTS_QUERY);
+				const query = ownerId
+					? `${ACCOUNTS_QUERY.trim().replace('ORDER BY name ASC', 'WHERE owner_id = ? ORDER BY name ASC')}`
+					: ACCOUNTS_QUERY;
+				const result = ownerId
+					? await db.execute(query, [ownerId])
+					: await db.execute(query);
 				setAccounts(result.rows as Account[]);
 			} catch (error) {
 				console.error('Error fetching accounts:', error);
@@ -36,7 +44,7 @@ export function useReactiveAccounts(db: DB | null): Account[] {
 		};
 
 		fetchAccounts();
-	}, [db, updateTrigger]);
+	}, [db, ownerId, updateTrigger]);
 
 	useEffect(() => {
 		const unsubscribe = subscribeToTableChanges('accounts', () => {
@@ -51,9 +59,14 @@ export function useReactiveAccounts(db: DB | null): Account[] {
 			return;
 		}
 
+		const query = ownerId
+			? `${ACCOUNTS_QUERY.trim().replace('ORDER BY name ASC', 'WHERE owner_id = ? ORDER BY name ASC')}`
+			: ACCOUNTS_QUERY;
+		const argumentsArray = ownerId ? [ownerId] : [];
+
 		const unsubscribe = db.reactiveExecute({
-			query: ACCOUNTS_QUERY,
-			arguments: [],
+			query,
+			arguments: argumentsArray,
 			fireOn: [{ table: 'accounts' }],
 			callback: () => {
 				setUpdateTrigger((prev) => prev + 1);
@@ -63,7 +76,7 @@ export function useReactiveAccounts(db: DB | null): Account[] {
 		return () => {
 			unsubscribe?.();
 		};
-	}, [db]);
+	}, [db, ownerId]);
 
 	return useMemo(() => [...accounts], [accounts]);
 }

--- a/src/hooks/useReactiveTransactions.ts
+++ b/src/hooks/useReactiveTransactions.ts
@@ -32,6 +32,7 @@ const LEGACY_TRANSACTIONS_QUERY = `
 
 export type TransactionRecord = {
 	id: string;
+	ownerId?: string | null;
 	accountId: string | null;
 	amount: number;
 	merchant: string | null;
@@ -41,7 +42,10 @@ export type TransactionRecord = {
 	createdAt: string;
 };
 
-export function useReactiveTransactions(db: DB | null) {
+export function useReactiveTransactions(
+	db: DB | null,
+	ownerId: string | null = null,
+) {
 	const [transactions, setTransactions] = useState<TransactionRecord[]>(
 		[],
 	);
@@ -55,7 +59,12 @@ export function useReactiveTransactions(db: DB | null) {
 
 		const fetchTransactions = async () => {
 			try {
-				const result = await db.execute(TRANSACTIONS_QUERY);
+				const query = ownerId
+					? `${TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+					: TRANSACTIONS_QUERY;
+				const result = ownerId
+					? await db.execute(query, [ownerId])
+					: await db.execute(query);
 
 				setTransactions(result.rows as TransactionRecord[]);
 			} catch (error) {
@@ -72,10 +81,13 @@ export function useReactiveTransactions(db: DB | null) {
 				}
 
 				try {
+					const fallbackQuery = ownerId
+						? `${LEGACY_TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+						: LEGACY_TRANSACTIONS_QUERY;
 					// Backward compatibility for existing databases before account_id migration.
-					const fallbackResult = await db.execute(
-						LEGACY_TRANSACTIONS_QUERY,
-					);
+					const fallbackResult = ownerId
+						? await db.execute(fallbackQuery, [ownerId])
+						: await db.execute(LEGACY_TRANSACTIONS_QUERY);
 
 					setTransactions(
 						fallbackResult.rows as TransactionRecord[],
@@ -91,7 +103,7 @@ export function useReactiveTransactions(db: DB | null) {
 		};
 
 		fetchTransactions();
-	}, [db, updateTrigger]);
+	}, [db, ownerId, updateTrigger]);
 
 	useEffect(() => {
 		const unsubscribe = subscribeToTableChanges('transactions', () => {
@@ -106,9 +118,14 @@ export function useReactiveTransactions(db: DB | null) {
 			return;
 		}
 
+		const query = ownerId
+			? `${TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+			: TRANSACTIONS_QUERY;
+		const argumentsArray = ownerId ? [ownerId] : [];
+
 		const unsubscribe = db.reactiveExecute({
-			query: TRANSACTIONS_QUERY,
-			arguments: [],
+			query,
+			arguments: argumentsArray,
 			fireOn: [{ table: 'transactions' }],
 			callback: () => {
 				setUpdateTrigger((prev) => prev + 1);
@@ -118,7 +135,7 @@ export function useReactiveTransactions(db: DB | null) {
 		return () => {
 			unsubscribe?.();
 		};
-	}, [db]);
+	}, [db, ownerId]);
 
 	return [...transactions];
 }

--- a/src/hooks/useReactiveTransactions.ts
+++ b/src/hooks/useReactiveTransactions.ts
@@ -60,7 +60,10 @@ export function useReactiveTransactions(
 		const fetchTransactions = async () => {
 			try {
 				const query = ownerId
-					? `${TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+					? `${TRANSACTIONS_QUERY.trim().replace(
+							'ORDER BY date DESC, created_at DESC',
+							'WHERE owner_id = ? ORDER BY date DESC, created_at DESC',
+					  )}`
 					: TRANSACTIONS_QUERY;
 				const result = ownerId
 					? await db.execute(query, [ownerId])
@@ -82,7 +85,10 @@ export function useReactiveTransactions(
 
 				try {
 					const fallbackQuery = ownerId
-						? `${LEGACY_TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+						? `${LEGACY_TRANSACTIONS_QUERY.trim().replace(
+								'ORDER BY date DESC, created_at DESC',
+								'WHERE owner_id = ? ORDER BY date DESC, created_at DESC',
+						  )}`
 						: LEGACY_TRANSACTIONS_QUERY;
 					// Backward compatibility for existing databases before account_id migration.
 					const fallbackResult = ownerId
@@ -119,7 +125,10 @@ export function useReactiveTransactions(
 		}
 
 		const query = ownerId
-			? `${TRANSACTIONS_QUERY.trim().replace('ORDER BY date DESC, created_at DESC', 'WHERE owner_id = ? ORDER BY date DESC, created_at DESC')}`
+			? `${TRANSACTIONS_QUERY.trim().replace(
+					'ORDER BY date DESC, created_at DESC',
+					'WHERE owner_id = ? ORDER BY date DESC, created_at DESC',
+			  )}`
 			: TRANSACTIONS_QUERY;
 		const argumentsArray = ownerId ? [ownerId] : [];
 

--- a/src/navigation/RootStack/RootStack.tsx
+++ b/src/navigation/RootStack/RootStack.tsx
@@ -1,6 +1,7 @@
 import AppStack from '@navigation/AppStack/AppStack';
 import AuthStack from '@navigation/AuthStack/AuthStack';
 import { navigationRef } from '@navigation/navigationService';
+import { useBackfillOwnerId } from '@hooks/useBackfillOwnerId';
 import { useAuthStore } from '@providers/AuthProvider';
 import { DatabaseProvider, useDatabase } from '@providers/DatabaseProvider';
 import { NavigationContainer } from '@react-navigation/native';
@@ -12,8 +13,10 @@ const dbService = DatabaseService.getInstance('budgetai.db', 'default');
 
 const DatabaseAppStack = () => {
 	const { db } = useDatabase();
+	const userId = useAuthStore((s) => s.userId);
 
 	useDevDataReset(db);
+	useBackfillOwnerId(db, userId);
 
 	return <AppStack />;
 };

--- a/src/navigation/RootStack/RootStack.tsx
+++ b/src/navigation/RootStack/RootStack.tsx
@@ -4,19 +4,51 @@ import { navigationRef } from '@navigation/navigationService';
 import { useBackfillOwnerId } from '@hooks/useBackfillOwnerId';
 import { useAuthStore } from '@providers/AuthProvider';
 import { DatabaseProvider, useDatabase } from '@providers/DatabaseProvider';
+import { useApiClient } from '@providers/ApiClientProvider';
 import { NavigationContainer } from '@react-navigation/native';
 import { DatabaseService } from '@services/DatabaseService';
+import { SyncService } from '@services/SyncService';
 import { useDevDataReset } from '@hooks/useDevDataReset';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 const dbService = DatabaseService.getInstance('budgetai.db', 'default');
 
 const DatabaseAppStack = () => {
 	const { db } = useDatabase();
-	const userId = useAuthStore((s) => s.userId);
+	const { userId, token } = useAuthStore();
+	const { api } = useApiClient();
 
-	useDevDataReset(db);
+	useDevDataReset(db, api);
 	useBackfillOwnerId(db, userId);
+
+	useEffect(() => {
+		api.setAuthToken(token);
+	}, [api, token]);
+
+	useEffect(() => {
+		if (!userId || !token) {
+			return;
+		}
+
+		const controller = new AbortController();
+		const syncService = new SyncService(db, api);
+
+		syncService
+			.probeEndpointAvailability(controller.signal)
+			.then(() =>
+				syncService.pullOwnerData(userId, controller.signal),
+			)
+			.catch((error) => {
+				console.error(
+					'[RootStack] Initial owner sync failed',
+					error,
+				);
+			});
+
+		return () => {
+			controller.abort();
+		};
+	}, [api, db, token, userId]);
 
 	return <AppStack />;
 };

--- a/src/providers/ApiClientProvider.tsx
+++ b/src/providers/ApiClientProvider.tsx
@@ -1,9 +1,11 @@
 import { ApiClient } from '@services/ApiClient';
 import React, { createContext } from 'react';
 
-const apiClient = new ApiClient(
-	'https://budget-ai-backend-f2124bc32a19.herokuapp.com',
-);
+// const apiClient = new ApiClient(
+// 	'https://budget-ai-backend-f2124bc32a19.herokuapp.com',
+// );
+
+const apiClient = new ApiClient('http://localhost:3001');
 
 const ApiClientContext = createContext<{ api: ApiClient } | null>(null);
 

--- a/src/providers/AuthProvider.test.tsx
+++ b/src/providers/AuthProvider.test.tsx
@@ -6,22 +6,28 @@ import {
 } from '@testing-library/react-native';
 import * as React from 'react';
 import { AuthProvider, useAuthStore } from './AuthProvider';
-import { StorageService } from '@services/StorageService';
+import { StorageKey } from '@enums/StorageKey';
 
 const mockAuthService = {
-	login: jest.fn().mockResolvedValue('mock-auth0-token'),
+	login: jest.fn().mockResolvedValue({
+		token: 'mock-auth0-token',
+		userId: 'auth0|123',
+	}),
 	logout: jest.fn().mockResolvedValue(undefined),
 };
 
 jest.mock('@services/StorageService', () => {
+	const mockStorage = {
+		saveItem: jest.fn().mockResolvedValue(undefined),
+		loadItem: jest.fn().mockResolvedValue(null),
+		clearItem: jest.fn().mockResolvedValue(undefined),
+	};
+
 	return {
 		StorageService: {
-			getInstance: jest.fn(() => ({
-				saveItem: jest.fn().mockResolvedValue(undefined),
-				loadItem: jest.fn().mockResolvedValue('saved-token'),
-				clearItem: jest.fn().mockResolvedValue(undefined),
-			})),
+			getInstance: jest.fn(() => mockStorage),
 		},
+		__mockStorage: mockStorage,
 	};
 });
 
@@ -33,14 +39,36 @@ jest.mock('@react-native-async-storage/async-storage', () => {
 	};
 });
 
+type MockStorage = {
+	saveItem: jest.Mock;
+	loadItem: jest.Mock;
+	clearItem: jest.Mock;
+};
+
+const mockStorage = (
+	jest.requireMock('@services/StorageService') as {
+		__mockStorage: MockStorage;
+	}
+).__mockStorage;
+
 describe('AuthProvider', () => {
-	it('renders children when token is set', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockStorage.loadItem.mockResolvedValue(null);
+	});
+
+	it('renders children when token is set', async () => {
 		const store = createAuthStore(mockAuthService);
+		(mockStorage.loadItem as jest.Mock).mockResolvedValue(null);
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
 		);
 
 		const { result } = renderHook(() => useAuthStore(), { wrapper });
+
+		await waitFor(() => {
+			expect(result.current.token).toBeNull();
+		});
 
 		testAct(() => {
 			result.current.setToken('test-token');
@@ -51,14 +79,17 @@ describe('AuthProvider', () => {
 
 	it('loads persisted token on mount', async () => {
 		const store = createAuthStore(mockAuthService);
-		const mockStorage = StorageService.getInstance('@auth');
-		const actions = store.createActions(jest.fn(), mockStorage);
-
-		// Set the token if provided
-		const token = 'saved-token';
-		testAct(() => {
-			actions.setToken(token);
-		});
+		(mockStorage.loadItem as jest.Mock).mockImplementation(
+			async (key: StorageKey) => {
+				if (key === StorageKey.AuthToken) {
+					return 'saved-token';
+				}
+				if (key === StorageKey.AuthUserId) {
+					return 'auth0|saved-user';
+				}
+				return null;
+			},
+		);
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
@@ -68,11 +99,13 @@ describe('AuthProvider', () => {
 
 		await waitFor(() => {
 			expect(result.current.token).toBe('saved-token');
+			expect(result.current.userId).toBe('auth0|saved-user');
 		});
 	});
 
-	it('setToken action updates token in context', () => {
+	it('setToken action updates token in context', async () => {
 		const store = createAuthStore(mockAuthService);
+		(mockStorage.loadItem as jest.Mock).mockResolvedValue(null);
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
@@ -80,7 +113,9 @@ describe('AuthProvider', () => {
 
 		const { result } = renderHook(() => useAuthStore(), { wrapper });
 
-		expect(result.current.token).toBeNull();
+		await waitFor(() => {
+			expect(result.current.token).toBeNull();
+		});
 
 		// Call setToken to update state
 		testAct(() => {
@@ -93,6 +128,7 @@ describe('AuthProvider', () => {
 
 	it('logout action resets token to null', async () => {
 		const store = createAuthStore(mockAuthService);
+		(mockStorage.loadItem as jest.Mock).mockResolvedValue(null);
 
 		const wrapper = ({ children }: { children: React.ReactNode }) => (
 			<AuthProvider store={store}>{children}</AuthProvider>
@@ -100,17 +136,29 @@ describe('AuthProvider', () => {
 
 		const { result } = renderHook(() => useAuthStore(), { wrapper });
 
-		// Set token first
-		testAct(() => {
-			result.current.setToken('token-to-logout');
+		await waitFor(() => {
+			expect(result.current.token).toBeNull();
+			expect(result.current.userId).toBeNull();
 		});
-		expect(result.current.token).toBe('token-to-logout');
+
+		testAct(() => {
+			result.current.setToken('token-to-logout', 'auth0|saved-user');
+		});
+
+		await waitFor(() => {
+			expect(result.current.token).toBe('token-to-logout');
+			expect(result.current.userId).toBe('auth0|saved-user');
+		});
 
 		// Then logout
 		await testAct(async () => {
 			await result.current.logout();
 		});
-		expect(result.current.token).toBeNull();
+
+		await waitFor(() => {
+			expect(result.current.token).toBeNull();
+			expect(result.current.userId).toBeNull();
+		});
 	});
 
 	it('throws when called outside AuthProvider', () => {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -45,11 +45,14 @@ export function AuthProvider({
 			const persistedToken = await storage.loadItem(
 				StorageKey.AuthToken,
 			);
+			const persistedUserId = await storage.loadItem(
+				StorageKey.AuthUserId,
+			);
 			console.debug(
 				'[AuthProvider] Loaded persisted token:',
 				persistedToken,
 			);
-			actions.setToken(persistedToken);
+			actions.setToken(persistedToken, persistedUserId);
 		}
 		loadPersisted();
 	}, [actions]);

--- a/src/repositories/AccountRepository.ts
+++ b/src/repositories/AccountRepository.ts
@@ -9,7 +9,10 @@ import type { Repository } from 'types/Repository';
 export class AccountRepository
 	implements Repository<NewAccountInput, Account>
 {
-	constructor(private db: DB) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+	) {}
 
 	getAll: () => Promise<Account[]> = async () => this.list();
 
@@ -24,6 +27,7 @@ export class AccountRepository
 	async list(): Promise<Account[]> {
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			account_type: string;
 			currency: string;
@@ -32,6 +36,7 @@ export class AccountRepository
 		}>(`
 			SELECT
 				id,
+				owner_id,
 				name,
 				account_type,
 				currency,
@@ -43,6 +48,7 @@ export class AccountRepository
 
 		return rows.map((row) => ({
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			name: String(row.name),
 			accountType: row.account_type as Account['accountType'],
 			currency: String(row.currency),
@@ -56,25 +62,36 @@ export class AccountRepository
 		const now = nowIso();
 		const accountType = input.accountType ?? 'cash';
 		const currency = input.currency ?? 'USD';
+		const ownerId = this.userId ?? input.ownerId ?? null;
 
 		await this.db.execute(
 			`
 			INSERT INTO accounts (
 				id,
+				owner_id,
 				name,
 				account_type,
 				currency,
 				created_at,
 				updated_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
 		`,
-			[id, input.name.trim(), accountType, currency, now, now],
+			[
+				id,
+				ownerId,
+				input.name.trim(),
+				accountType,
+				currency,
+				now,
+				now,
+			],
 		);
 		notifyTableChanged('accounts');
 
 		return {
 			id,
+			ownerId,
 			name: input.name.trim(),
 			accountType,
 			currency,
@@ -89,6 +106,7 @@ export class AccountRepository
 	): Promise<Account> {
 		const existing = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			account_type: string;
 			currency: string;
@@ -98,6 +116,7 @@ export class AccountRepository
 			`
 			SELECT
 				id,
+				owner_id,
 				name,
 				account_type,
 				currency,
@@ -121,6 +140,10 @@ export class AccountRepository
 			input.accountType ??
 			(String(row.account_type) as Account['accountType']);
 		const currency = input.currency ?? String(row.currency);
+		const ownerId =
+			input.ownerId === undefined
+				? row.owner_id
+				: input.ownerId ?? null;
 
 		await executeTransaction(this.db, [
 			{
@@ -139,6 +162,7 @@ export class AccountRepository
 
 		return {
 			id: String(row.id),
+			ownerId,
 			name,
 			accountType,
 			currency,
@@ -160,6 +184,7 @@ export class AccountRepository
 	async ensureDefaultAccount(): Promise<Account> {
 		const existing = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			account_type: string;
 			currency: string;
@@ -169,6 +194,7 @@ export class AccountRepository
 			`
 			SELECT
 				id,
+				owner_id,
 				name,
 				account_type,
 				currency,
@@ -185,6 +211,7 @@ export class AccountRepository
 			const row = existing[0];
 			return {
 				id: String(row.id),
+				ownerId: row.owner_id ? String(row.owner_id) : null,
 				name: String(row.name),
 				accountType: row.account_type as Account['accountType'],
 				currency: String(row.currency),

--- a/src/repositories/AccountRepository.ts
+++ b/src/repositories/AccountRepository.ts
@@ -2,6 +2,7 @@ import { notifyTableChanged } from '@db/databaseChangeNotifier';
 import { executeTransaction } from '@db/executeTransaction';
 import { Account, NewAccountInput } from 'types/Account';
 import { DB, Scalar } from '@op-engineering/op-sqlite';
+import { ApiClient, type ApiError } from '@services/ApiClient';
 import { nowIso } from '@utils/dateUtil';
 import { generateUniqueId } from '@utils/randomIdUtils';
 import type { Repository } from 'types/Repository';
@@ -9,7 +10,80 @@ import type { Repository } from 'types/Repository';
 export class AccountRepository
 	implements Repository<NewAccountInput, Account>
 {
-	constructor(private db: DB, private userId: string | null = null) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+		private api: ApiClient,
+	) {}
+
+	private async syncCreatedAccount(account: Account): Promise<void> {
+		try {
+			await this.api.accounts.create({
+				id: account.id,
+				name: account.name,
+				accountType: account.accountType,
+				currency: account.currency,
+				createdAt: account.createdAt,
+				updatedAt: account.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[AccountRepository] Failed to sync created account ${
+					account.id
+				}: ${(error as ApiError)?.message ?? 'Unknown error'}`,
+			);
+		}
+	}
+
+	private async syncUpdatedAccount(
+		id: string,
+		account: Account,
+	): Promise<void> {
+		try {
+			await this.api.accounts.update(id, {
+				name: account.name,
+				accountType: account.accountType,
+				currency: account.currency,
+				updatedAt: account.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[AccountRepository] Failed to sync updated account ${id}: ${
+					(error as ApiError)?.message ?? 'Unknown error'
+				}`,
+			);
+		}
+	}
+
+	private async syncDeletedAccount(id: string): Promise<void> {
+		try {
+			await this.api.accounts.delete(id);
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[AccountRepository] Failed to sync deleted account ${id}: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
+
+	private async syncClearedAccounts(): Promise<void> {
+		try {
+			await this.api.accounts.clear();
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[AccountRepository] Failed to sync cleared accounts: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
 
 	getAll: () => Promise<Account[]> = async () => this.list();
 
@@ -92,7 +166,7 @@ export class AccountRepository
 		);
 		notifyTableChanged('accounts');
 
-		return {
+		const created: Account = {
 			id,
 			ownerId,
 			name: input.name.trim(),
@@ -101,6 +175,10 @@ export class AccountRepository
 			createdAt: now,
 			updatedAt: now,
 		};
+
+		await this.syncCreatedAccount(created);
+
+		return created;
 	}
 
 	async update(
@@ -163,7 +241,7 @@ export class AccountRepository
 		]);
 		notifyTableChanged('accounts');
 
-		return {
+		const updated: Account = {
 			id: String(row.id),
 			ownerId,
 			name,
@@ -172,9 +250,15 @@ export class AccountRepository
 			createdAt: String(row.created_at),
 			updatedAt: now,
 		};
+
+		await this.syncUpdatedAccount(id, updated);
+
+		return updated;
 	}
 
 	async delete(id: string): Promise<void> {
+		await this.syncDeletedAccount(id);
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM accounts WHERE id = ?',
@@ -230,6 +314,8 @@ export class AccountRepository
 	}
 
 	async clearAll(): Promise<void> {
+		await this.syncClearedAccounts();
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM accounts',

--- a/src/repositories/AccountRepository.ts
+++ b/src/repositories/AccountRepository.ts
@@ -9,10 +9,7 @@ import type { Repository } from 'types/Repository';
 export class AccountRepository
 	implements Repository<NewAccountInput, Account>
 {
-	constructor(
-		private db: DB,
-		private userId: string | null = null,
-	) {}
+	constructor(private db: DB, private userId: string | null = null) {}
 
 	getAll: () => Promise<Account[]> = async () => this.list();
 
@@ -25,9 +22,7 @@ export class AccountRepository
 	}
 
 	async list(): Promise<Account[]> {
-		const ownerFilter = this.userId
-			? 'WHERE owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'WHERE owner_id = ?' : '';
 		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
@@ -37,7 +32,8 @@ export class AccountRepository
 			currency: string;
 			created_at: string;
 			updated_at: string;
-		}>(`
+		}>(
+			`
 			SELECT
 				id,
 				owner_id,
@@ -49,7 +45,9 @@ export class AccountRepository
 			FROM accounts
 			${ownerFilter}
 			ORDER BY name ASC
-		`, args);
+		`,
+			args,
+		);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -187,9 +185,7 @@ export class AccountRepository
 	}
 
 	async ensureDefaultAccount(): Promise<Account> {
-		const ownerFilter = this.userId
-			? 'AND owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'AND owner_id = ?' : '';
 		const args = this.userId ? ['Cash', this.userId] : ['Cash'];
 		const existing = await this.executeQuery<{
 			id: string;

--- a/src/repositories/AccountRepository.ts
+++ b/src/repositories/AccountRepository.ts
@@ -25,6 +25,10 @@ export class AccountRepository
 	}
 
 	async list(): Promise<Account[]> {
+		const ownerFilter = this.userId
+			? 'WHERE owner_id = ?'
+			: '';
+		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -43,8 +47,9 @@ export class AccountRepository
 				created_at,
 				updated_at
 			FROM accounts
+			${ownerFilter}
 			ORDER BY name ASC
-		`);
+		`, args);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -182,6 +187,10 @@ export class AccountRepository
 	}
 
 	async ensureDefaultAccount(): Promise<Account> {
+		const ownerFilter = this.userId
+			? 'AND owner_id = ?'
+			: '';
+		const args = this.userId ? ['Cash', this.userId] : ['Cash'];
 		const existing = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -202,9 +211,10 @@ export class AccountRepository
 				updated_at
 			FROM accounts
 			WHERE name = ?
+			${ownerFilter}
 			LIMIT 1
 		`,
-			['Cash'],
+			args,
 		);
 
 		if (existing[0]) {

--- a/src/repositories/BudgetRepository.ts
+++ b/src/repositories/BudgetRepository.ts
@@ -9,7 +9,10 @@ import { Budget, NewBudgetInput } from 'types/Budget';
 export class BudgetRepository
 	implements Repository<NewBudgetInput, Budget>
 {
-	constructor(private db: DB) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+	) {}
 
 	private async executeQuery<T>(
 		query: string,
@@ -23,11 +26,13 @@ export class BudgetRepository
 		const id = generateUniqueId('bdgt');
 		const now = nowIso();
 		const name = input.name.trim();
+		const ownerId = this.userId ?? input.ownerId ?? null;
 
 		await this.db.execute(
 			`
 			INSERT INTO budgets (
 				id,
+				owner_id,
 				name,
 				amount,
 				category_id,
@@ -36,10 +41,11 @@ export class BudgetRepository
 				created_at,
 				updated_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			[
 				id,
+				ownerId,
 				name,
 				Math.abs(input.amount),
 				input.categoryId ?? null,
@@ -53,6 +59,7 @@ export class BudgetRepository
 
 		return {
 			id,
+			ownerId,
 			name,
 			amount: Math.abs(input.amount),
 			categoryId: input.categoryId ?? null,
@@ -134,6 +141,7 @@ export class BudgetRepository
 	async list(): Promise<Budget[]> {
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			amount: number;
 			category_id: string | null;
@@ -144,6 +152,7 @@ export class BudgetRepository
 		}>(`
 			SELECT
 				id,
+				owner_id,
 				name,
 				amount,
 				category_id,
@@ -157,6 +166,7 @@ export class BudgetRepository
 
 		return rows.map((row) => ({
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			name: String(row.name),
 			amount: Number(row.amount),
 			categoryId: row.category_id ? String(row.category_id) : null,
@@ -180,6 +190,7 @@ export class BudgetRepository
 	private async getById(id: string): Promise<Budget | null> {
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			amount: number;
 			category_id: string | null;
@@ -191,6 +202,7 @@ export class BudgetRepository
 			`
 			SELECT
 				id,
+				owner_id,
 				name,
 				amount,
 				category_id,
@@ -212,6 +224,7 @@ export class BudgetRepository
 		const row = rows[0];
 		return {
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			name: String(row.name),
 			amount: Number(row.amount),
 			categoryId: row.category_id ? String(row.category_id) : null,

--- a/src/repositories/BudgetRepository.ts
+++ b/src/repositories/BudgetRepository.ts
@@ -1,6 +1,7 @@
 import { notifyTableChanged } from '@db/databaseChangeNotifier';
 import { executeTransaction } from '@db/executeTransaction';
 import { DB, Scalar } from '@op-engineering/op-sqlite';
+import { ApiClient, type ApiError } from '@services/ApiClient';
 import { nowIso } from '@utils/dateUtil';
 import { generateUniqueId } from '@utils/randomIdUtils';
 import type { Repository } from 'types/Repository';
@@ -9,7 +10,84 @@ import { Budget, NewBudgetInput } from 'types/Budget';
 export class BudgetRepository
 	implements Repository<NewBudgetInput, Budget>
 {
-	constructor(private db: DB, private userId: string | null = null) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+		private api: ApiClient,
+	) {}
+
+	private async syncCreatedBudget(budget: Budget): Promise<void> {
+		try {
+			await this.api.budgets.create({
+				id: budget.id,
+				name: budget.name,
+				amount: budget.amount,
+				categoryId: budget.categoryId,
+				periodStart: budget.periodStart,
+				periodEnd: budget.periodEnd,
+				createdAt: budget.createdAt,
+				updatedAt: budget.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[BudgetRepository] Failed to sync created budget ${
+					budget.id
+				}: ${(error as ApiError)?.message ?? 'Unknown error'}`,
+			);
+		}
+	}
+
+	private async syncUpdatedBudget(
+		id: string,
+		budget: Budget,
+	): Promise<void> {
+		try {
+			await this.api.budgets.update(id, {
+				name: budget.name,
+				amount: budget.amount,
+				categoryId: budget.categoryId,
+				periodStart: budget.periodStart,
+				periodEnd: budget.periodEnd,
+				updatedAt: budget.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[BudgetRepository] Failed to sync updated budget ${id}: ${
+					(error as ApiError)?.message ?? 'Unknown error'
+				}`,
+			);
+		}
+	}
+
+	private async syncDeletedBudget(id: string): Promise<void> {
+		try {
+			await this.api.budgets.delete(id);
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[BudgetRepository] Failed to sync deleted budget ${id}: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
+
+	private async syncClearedBudgets(): Promise<void> {
+		try {
+			await this.api.budgets.clear();
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[BudgetRepository] Failed to sync cleared budgets: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
 
 	private async executeQuery<T>(
 		query: string,
@@ -54,7 +132,7 @@ export class BudgetRepository
 		);
 		notifyTableChanged('budgets');
 
-		return {
+		const created: Budget = {
 			id,
 			ownerId,
 			name,
@@ -65,6 +143,10 @@ export class BudgetRepository
 			createdAt: now,
 			updatedAt: now,
 		};
+
+		await this.syncCreatedBudget(created);
+
+		return created;
 	}
 
 	async update(
@@ -114,7 +196,7 @@ export class BudgetRepository
 		]);
 		notifyTableChanged('budgets');
 
-		return {
+		const updated: Budget = {
 			...existing,
 			name,
 			amount,
@@ -123,9 +205,15 @@ export class BudgetRepository
 			periodEnd,
 			updatedAt: now,
 		};
+
+		await this.syncUpdatedBudget(id, updated);
+
+		return updated;
 	}
 
 	async delete(id: string): Promise<void> {
+		await this.syncDeletedBudget(id);
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM budgets WHERE id = ?',
@@ -181,6 +269,8 @@ export class BudgetRepository
 	}
 
 	async clearAll(): Promise<void> {
+		await this.syncClearedBudgets();
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM budgets',

--- a/src/repositories/BudgetRepository.ts
+++ b/src/repositories/BudgetRepository.ts
@@ -9,10 +9,7 @@ import { Budget, NewBudgetInput } from 'types/Budget';
 export class BudgetRepository
 	implements Repository<NewBudgetInput, Budget>
 {
-	constructor(
-		private db: DB,
-		private userId: string | null = null,
-	) {}
+	constructor(private db: DB, private userId: string | null = null) {}
 
 	private async executeQuery<T>(
 		query: string,
@@ -139,9 +136,7 @@ export class BudgetRepository
 	}
 
 	async list(): Promise<Budget[]> {
-		const ownerFilter = this.userId
-			? 'WHERE owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'WHERE owner_id = ?' : '';
 		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
@@ -153,7 +148,8 @@ export class BudgetRepository
 			period_end: string;
 			created_at: string;
 			updated_at: string;
-		}>(`
+		}>(
+			`
 			SELECT
 				id,
 				owner_id,
@@ -167,7 +163,9 @@ export class BudgetRepository
 			FROM budgets
 			${ownerFilter}
 			ORDER BY period_start DESC, created_at DESC
-		`, args);
+		`,
+			args,
+		);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -193,9 +191,7 @@ export class BudgetRepository
 	}
 
 	private async getById(id: string): Promise<Budget | null> {
-		const ownerFilter = this.userId
-			? 'AND owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'AND owner_id = ?' : '';
 		const args = this.userId ? [id, this.userId] : [id];
 		const rows = await this.executeQuery<{
 			id: string;

--- a/src/repositories/BudgetRepository.ts
+++ b/src/repositories/BudgetRepository.ts
@@ -139,6 +139,10 @@ export class BudgetRepository
 	}
 
 	async list(): Promise<Budget[]> {
+		const ownerFilter = this.userId
+			? 'WHERE owner_id = ?'
+			: '';
+		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -161,8 +165,9 @@ export class BudgetRepository
 				created_at,
 				updated_at
 			FROM budgets
+			${ownerFilter}
 			ORDER BY period_start DESC, created_at DESC
-		`);
+		`, args);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -188,6 +193,10 @@ export class BudgetRepository
 	}
 
 	private async getById(id: string): Promise<Budget | null> {
+		const ownerFilter = this.userId
+			? 'AND owner_id = ?'
+			: '';
+		const args = this.userId ? [id, this.userId] : [id];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -212,9 +221,10 @@ export class BudgetRepository
 				updated_at
 			FROM budgets
 			WHERE id = ?
+			${ownerFilter}
 			LIMIT 1
 		`,
-			[id],
+			args,
 		);
 
 		if (!rows[0]) {

--- a/src/repositories/CategoryRepository.ts
+++ b/src/repositories/CategoryRepository.ts
@@ -9,7 +9,7 @@ import { Category, NewCategoryInput } from 'types/Category';
 export class CategoryRepository
 	implements Repository<NewCategoryInput, Category>
 {
-	constructor(private db: DB) {}
+	constructor(private db: DB, private userId: string | null = null) {}
 
 	private async executeQuery<T>(
 		query: string,
@@ -25,25 +25,28 @@ export class CategoryRepository
 		const name = input.name.trim();
 		const color = input.color?.trim() || null;
 		const icon = input.icon?.trim() || null;
+		const ownerId = this.userId ?? input.ownerId ?? null;
 
 		await this.db.execute(
 			`
 			INSERT INTO categories (
 				id,
+				owner_id,
 				name,
 				color,
 				icon,
 				created_at,
 				updated_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
 		`,
-			[id, name, color, icon, now, now],
+			[id, ownerId, name, color, icon, now, now],
 		);
 		notifyTableChanged('categories');
 
 		return {
 			id,
+			ownerId,
 			name,
 			color,
 			icon,
@@ -109,6 +112,7 @@ export class CategoryRepository
 	async list(): Promise<Category[]> {
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			color: string | null;
 			icon: string | null;
@@ -117,6 +121,7 @@ export class CategoryRepository
 		}>(`
 			SELECT
 				id,
+				owner_id,
 				name,
 				color,
 				icon,
@@ -128,6 +133,7 @@ export class CategoryRepository
 
 		return rows.map((row) => ({
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			name: String(row.name),
 			color: row.color ? String(row.color) : null,
 			icon: row.icon ? String(row.icon) : null,
@@ -149,6 +155,7 @@ export class CategoryRepository
 	private async getById(id: string): Promise<Category | null> {
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			name: string;
 			color: string | null;
 			icon: string | null;
@@ -158,6 +165,7 @@ export class CategoryRepository
 			`
 			SELECT
 				id,
+				owner_id,
 				name,
 				color,
 				icon,
@@ -177,6 +185,7 @@ export class CategoryRepository
 		const row = rows[0];
 		return {
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			name: String(row.name),
 			color: row.color ? String(row.color) : null,
 			icon: row.icon ? String(row.icon) : null,

--- a/src/repositories/CategoryRepository.ts
+++ b/src/repositories/CategoryRepository.ts
@@ -110,9 +110,7 @@ export class CategoryRepository
 	}
 
 	async list(): Promise<Category[]> {
-		const ownerFilter = this.userId
-			? 'WHERE owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'WHERE owner_id = ?' : '';
 		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
@@ -122,7 +120,8 @@ export class CategoryRepository
 			icon: string | null;
 			created_at: string;
 			updated_at: string;
-		}>(`
+		}>(
+			`
 			SELECT
 				id,
 				owner_id,
@@ -134,7 +133,9 @@ export class CategoryRepository
 			FROM categories
 			${ownerFilter}
 			ORDER BY name ASC
-		`, args);
+		`,
+			args,
+		);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -158,9 +159,7 @@ export class CategoryRepository
 	}
 
 	private async getById(id: string): Promise<Category | null> {
-		const ownerFilter = this.userId
-			? 'AND owner_id = ?'
-			: '';
+		const ownerFilter = this.userId ? 'AND owner_id = ?' : '';
 		const args = this.userId ? [id, this.userId] : [id];
 		const rows = await this.executeQuery<{
 			id: string;

--- a/src/repositories/CategoryRepository.ts
+++ b/src/repositories/CategoryRepository.ts
@@ -1,6 +1,7 @@
 import { notifyTableChanged } from '@db/databaseChangeNotifier';
 import { executeTransaction } from '@db/executeTransaction';
 import { DB, Scalar } from '@op-engineering/op-sqlite';
+import { ApiClient, type ApiError } from '@services/ApiClient';
 import { nowIso } from '@utils/dateUtil';
 import { generateUniqueId } from '@utils/randomIdUtils';
 import type { Repository } from 'types/Repository';
@@ -9,7 +10,80 @@ import { Category, NewCategoryInput } from 'types/Category';
 export class CategoryRepository
 	implements Repository<NewCategoryInput, Category>
 {
-	constructor(private db: DB, private userId: string | null = null) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+		private api: ApiClient,
+	) {}
+
+	private async syncCreatedCategory(category: Category): Promise<void> {
+		try {
+			await this.api.categories.create({
+				id: category.id,
+				name: category.name,
+				color: category.color,
+				icon: category.icon,
+				createdAt: category.createdAt,
+				updatedAt: category.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[CategoryRepository] Failed to sync created category ${
+					category.id
+				}: ${(error as ApiError)?.message ?? 'Unknown error'}`,
+			);
+		}
+	}
+
+	private async syncUpdatedCategory(
+		id: string,
+		category: Category,
+	): Promise<void> {
+		try {
+			await this.api.categories.update(id, {
+				name: category.name,
+				color: category.color,
+				icon: category.icon,
+				updatedAt: category.updatedAt,
+			});
+		} catch (error) {
+			console.warn(
+				`[CategoryRepository] Failed to sync updated category ${id}: ${
+					(error as ApiError)?.message ?? 'Unknown error'
+				}`,
+			);
+		}
+	}
+
+	private async syncDeletedCategory(id: string): Promise<void> {
+		try {
+			await this.api.categories.delete(id);
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[CategoryRepository] Failed to sync deleted category ${id}: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
+
+	private async syncClearedCategories(): Promise<void> {
+		try {
+			await this.api.categories.clear();
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				console.warn(
+					`[CategoryRepository] Failed to sync cleared categories: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+	}
 
 	private async executeQuery<T>(
 		query: string,
@@ -44,7 +118,7 @@ export class CategoryRepository
 		);
 		notifyTableChanged('categories');
 
-		return {
+		const created: Category = {
 			id,
 			ownerId,
 			name,
@@ -53,6 +127,10 @@ export class CategoryRepository
 			createdAt: now,
 			updatedAt: now,
 		};
+
+		await this.syncCreatedCategory(created);
+
+		return created;
 	}
 
 	async update(
@@ -90,16 +168,22 @@ export class CategoryRepository
 		]);
 		notifyTableChanged('categories');
 
-		return {
+		const updated: Category = {
 			...existing,
 			name,
 			color,
 			icon,
 			updatedAt: now,
 		};
+
+		await this.syncUpdatedCategory(id, updated);
+
+		return updated;
 	}
 
 	async delete(id: string): Promise<void> {
+		await this.syncDeletedCategory(id);
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM categories WHERE id = ?',
@@ -149,6 +233,8 @@ export class CategoryRepository
 	}
 
 	async clearAll(): Promise<void> {
+		await this.syncClearedCategories();
+
 		await executeTransaction(this.db, [
 			{
 				sql: 'DELETE FROM categories',

--- a/src/repositories/CategoryRepository.ts
+++ b/src/repositories/CategoryRepository.ts
@@ -110,6 +110,10 @@ export class CategoryRepository
 	}
 
 	async list(): Promise<Category[]> {
+		const ownerFilter = this.userId
+			? 'WHERE owner_id = ?'
+			: '';
+		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -128,8 +132,9 @@ export class CategoryRepository
 				created_at,
 				updated_at
 			FROM categories
+			${ownerFilter}
 			ORDER BY name ASC
-		`);
+		`, args);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -153,6 +158,10 @@ export class CategoryRepository
 	}
 
 	private async getById(id: string): Promise<Category | null> {
+		const ownerFilter = this.userId
+			? 'AND owner_id = ?'
+			: '';
+		const args = this.userId ? [id, this.userId] : [id];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -173,9 +182,10 @@ export class CategoryRepository
 				updated_at
 			FROM categories
 			WHERE id = ?
+			${ownerFilter}
 			LIMIT 1
 		`,
-			[id],
+			args,
 		);
 
 		if (!rows[0]) {

--- a/src/repositories/TransactionRepository.ts
+++ b/src/repositories/TransactionRepository.ts
@@ -1,11 +1,29 @@
 import { notifyTableChanged } from '@db/databaseChangeNotifier';
 import { executeTransaction } from '@db/executeTransaction';
 import { DB, Scalar } from '@op-engineering/op-sqlite';
+import { ApiClient, type ApiError } from '@services/ApiClient';
 import { nowIso } from '@utils/dateUtil';
 import { repositoryLog } from '@utils/logUtils';
 import { generateUniqueId } from '@utils/randomIdUtils';
 import type { Repository } from 'types/Repository';
 import { NewTransactionInput, Transaction } from 'types/Transaction';
+
+function isDuplicateTransactionIdError(error: ApiError | undefined): boolean {
+	if (!error) {
+		return false;
+	}
+
+	if (error.status === 409) {
+		return true;
+	}
+
+	const message = (error.message ?? '').toLowerCase();
+	return (
+		error.status === 400 &&
+		message.includes('unique constraint failed') &&
+		message.includes('transactions.id')
+	);
+}
 
 export class TransactionRepository
 	implements Repository<NewTransactionInput, Transaction>
@@ -13,12 +31,66 @@ export class TransactionRepository
 	constructor(
 		private db: DB,
 		private userId: string | null = null,
+		private api: ApiClient,
 	) {}
+
+	private async syncCreatedTransaction(transaction: Transaction) {
+		try {
+			await this.api.transactions.create({
+				id: transaction.id,
+				accountId: transaction.accountId,
+				amount: transaction.amount,
+				merchant: transaction.merchant,
+				category: transaction.category,
+				transactionType: transaction.transactionType,
+				date: transaction.date,
+				source: transaction.source,
+				createdAt: transaction.createdAt,
+			});
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (isDuplicateTransactionIdError(apiError)) {
+				return;
+			}
+
+			console.warn(
+				`[TransactionRepository] Failed to sync created transaction ${
+					transaction.id
+				} (${apiError?.status ?? 0}): ${
+					apiError?.message ?? 'Unknown error'
+				}`,
+			);
+		}
+	}
+
+	private async syncDeletedTransaction(id: string): Promise<void> {
+		try {
+			await this.api.transactions.delete(id);
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				throw error;
+			}
+		}
+	}
+
+	private async syncClearedTransactions(): Promise<void> {
+		try {
+			await this.api.transactions.clear();
+		} catch (error) {
+			const apiError = error as ApiError;
+			if (apiError?.status !== 404) {
+				throw error;
+			}
+		}
+	}
 
 	delete: (id: string) => Promise<void> = async (_id) => {
 		if (!this.db) {
 			throw new Error('Database not initialized');
 		}
+
+		await this.syncDeletedTransaction(_id);
 
 		await executeTransaction(this.db, [
 			{
@@ -65,9 +137,10 @@ export class TransactionRepository
 					transaction_type,
 					source,
 					date,
-					created_at
+					created_at,
+					sync_status
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`,
 				args: [
 					id,
@@ -80,12 +153,13 @@ export class TransactionRepository
 					input.source,
 					transactionDate,
 					createdAt,
+					'pending',
 				],
 			},
 		]);
 		notifyTableChanged('transactions');
 
-		return {
+		const transaction: Transaction = {
 			id,
 			ownerId,
 			accountId: input.accountId ?? null,
@@ -95,8 +169,13 @@ export class TransactionRepository
 			transactionType: input.transactionType,
 			date: transactionDate,
 			source: input.source,
+			syncStatus: 'pending',
 			createdAt,
 		};
+
+		await this.syncCreatedTransaction(transaction);
+
+		return transaction;
 	}
 
 	async update(
@@ -176,7 +255,8 @@ export class TransactionRepository
 						category = ?,
 						transaction_type = ?,
 						source = ?,
-						date = ?
+						date = ?,
+						sync_status = ?
 					WHERE id = ?
 				`,
 				args: [
@@ -187,6 +267,7 @@ export class TransactionRepository
 					transactionType,
 					source,
 					date,
+					'pending',
 					id,
 				],
 			},
@@ -204,16 +285,14 @@ export class TransactionRepository
 			date,
 			source: source as Transaction['source'],
 			createdAt: String(existing.created_at),
-			syncStatus: existing.sync_status
-				? (String(
-						existing.sync_status,
-				  ) as Transaction['syncStatus'])
-				: 'synced',
+			syncStatus: 'pending',
 		};
 	}
 
 	async list(): Promise<Transaction[]> {
 		repositoryLog.debug('Fetching all transactions');
+		const ownerFilter = this.userId ? 'WHERE owner_id = ?' : '';
+		const args = this.userId ? [this.userId] : [];
 		const rows = await this.executeQuery<{
 			id: string;
 			owner_id: string | null;
@@ -226,7 +305,8 @@ export class TransactionRepository
 			created_at: string;
 			sync_status?: string;
 			source?: string;
-		}>(`
+		}>(
+			`
 			SELECT
 				id,
 				owner_id,
@@ -240,8 +320,11 @@ export class TransactionRepository
 				sync_status,
 				source
 			FROM transactions
+			${ownerFilter}
 			ORDER BY date DESC, created_at DESC
-		`);
+		`,
+			args,
+		);
 
 		return rows.map((row) => ({
 			id: String(row.id),
@@ -270,10 +353,15 @@ export class TransactionRepository
 		if (!this.db) {
 			throw new Error('Database not initialized');
 		}
+
+		await this.syncClearedTransactions();
+
+		const ownerFilter = this.userId ? 'WHERE owner_id = ?' : '';
+		const args = this.userId ? [this.userId] : [];
 		await executeTransaction(this.db, [
 			{
-				sql: 'DELETE FROM transactions',
-				args: [],
+				sql: `DELETE FROM transactions ${ownerFilter}`,
+				args,
 			},
 		]);
 		notifyTableChanged('transactions');

--- a/src/repositories/TransactionRepository.ts
+++ b/src/repositories/TransactionRepository.ts
@@ -10,7 +10,10 @@ import { NewTransactionInput, Transaction } from 'types/Transaction';
 export class TransactionRepository
 	implements Repository<NewTransactionInput, Transaction>
 {
-	constructor(private db: DB) {}
+	constructor(
+		private db: DB,
+		private userId: string | null = null,
+	) {}
 
 	delete: (id: string) => Promise<void> = async (_id) => {
 		if (!this.db) {
@@ -47,12 +50,14 @@ export class TransactionRepository
 		const transactionDate = input.date ?? createdAt;
 		const merchant = input.merchant?.trim() || null;
 		const category = input.category?.trim() || null;
+		const ownerId = this.userId ?? input.ownerId ?? null;
 
 		await executeTransaction(this.db, [
 			{
 				sql: `
 				INSERT INTO transactions (
 					id,
+					owner_id,
 					account_id,
 					amount,
 					merchant,
@@ -62,10 +67,11 @@ export class TransactionRepository
 					date,
 					created_at
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`,
 				args: [
 					id,
+					ownerId,
 					input.accountId ?? null,
 					Math.abs(input.amount),
 					merchant,
@@ -81,6 +87,7 @@ export class TransactionRepository
 
 		return {
 			id,
+			ownerId,
 			accountId: input.accountId ?? null,
 			amount: Math.abs(input.amount),
 			merchant,
@@ -98,6 +105,7 @@ export class TransactionRepository
 	): Promise<Transaction> {
 		const existingRows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			account_id: string | null;
 			amount: number;
 			merchant: string | null;
@@ -111,6 +119,7 @@ export class TransactionRepository
 			`
 			SELECT
 				id,
+				owner_id,
 				account_id,
 				amount,
 				merchant,
@@ -136,6 +145,10 @@ export class TransactionRepository
 			input.accountId === undefined
 				? existing.account_id
 				: input.accountId ?? null;
+		const ownerId =
+			input.ownerId === undefined
+				? existing.owner_id
+				: input.ownerId ?? null;
 		const amount =
 			input.amount === undefined
 				? Number(existing.amount)
@@ -182,6 +195,7 @@ export class TransactionRepository
 
 		return {
 			id: String(existing.id),
+			ownerId,
 			accountId,
 			amount,
 			merchant,
@@ -202,6 +216,7 @@ export class TransactionRepository
 		repositoryLog.debug('Fetching all transactions');
 		const rows = await this.executeQuery<{
 			id: string;
+			owner_id: string | null;
 			account_id: string | null;
 			amount: number;
 			merchant: string | null;
@@ -214,6 +229,7 @@ export class TransactionRepository
 		}>(`
 			SELECT
 				id,
+				owner_id,
 				account_id,
 				amount,
 				merchant,
@@ -229,6 +245,7 @@ export class TransactionRepository
 
 		return rows.map((row) => ({
 			id: String(row.id),
+			ownerId: row.owner_id ? String(row.owner_id) : null,
 			accountId: row.account_id ? String(row.account_id) : null,
 			amount: Number(row.amount),
 			merchant: row.merchant ? String(row.merchant) : null,

--- a/src/repositories/TransactionRepository.ts
+++ b/src/repositories/TransactionRepository.ts
@@ -8,7 +8,9 @@ import { generateUniqueId } from '@utils/randomIdUtils';
 import type { Repository } from 'types/Repository';
 import { NewTransactionInput, Transaction } from 'types/Transaction';
 
-function isDuplicateTransactionIdError(error: ApiError | undefined): boolean {
+function isDuplicateTransactionIdError(
+	error: ApiError | undefined,
+): boolean {
 	if (!error) {
 		return false;
 	}

--- a/src/repositories/TransactionRepository.ts
+++ b/src/repositories/TransactionRepository.ts
@@ -71,7 +71,11 @@ export class TransactionRepository
 		} catch (error) {
 			const apiError = error as ApiError;
 			if (apiError?.status !== 404) {
-				throw error;
+				console.warn(
+					`[TransactionRepository] Failed to sync deleted transaction ${id}: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
 			}
 		}
 	}
@@ -82,7 +86,11 @@ export class TransactionRepository
 		} catch (error) {
 			const apiError = error as ApiError;
 			if (apiError?.status !== 404) {
-				throw error;
+				console.warn(
+					`[TransactionRepository] Failed to sync cleared transactions: ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
 			}
 		}
 	}

--- a/src/screens/HomeScreen/AiChatView.tsx
+++ b/src/screens/HomeScreen/AiChatView.tsx
@@ -61,7 +61,7 @@ const AiChatView = ({
 					new AIConversationRepository(db),
 					new TransactionRepository(db, userId, api),
 					api,
-					new CategoryRepository(db, userId),
+					new CategoryRepository(db, userId, api),
 				).sendMessageAndApplyActions({
 					threadId: threadId,
 					userText: trimmed,

--- a/src/screens/HomeScreen/AiChatView.tsx
+++ b/src/screens/HomeScreen/AiChatView.tsx
@@ -6,6 +6,7 @@ import { AIMessage } from '@db/types';
 import { useBackendHealth } from '@hooks/useBackendHealth';
 import useKeyboardShift from '@hooks/useKeyboardShift';
 import { useApiClient } from '@providers/ApiClientProvider';
+import { useAuthStore } from '@providers/AuthProvider';
 import { useDatabase } from '@providers/DatabaseProvider';
 import { useTheme } from '@providers/ThemeProvider';
 import { AIConversationRepository } from '@repositories/AIConversationRepository';
@@ -42,6 +43,7 @@ const AiChatView = ({
 	const styles = useMemo(() => createStyles(colors), [colors]);
 	const api = useApiClient((s) => s);
 	const { db } = useDatabase();
+	const { userId } = useAuthStore();
 	const { backendStatus } = useBackendHealth(api.health.check);
 
 	const onMessageSend = useCallback(async () => {
@@ -57,9 +59,9 @@ const AiChatView = ({
 
 				await new AIActionHandler(
 					new AIConversationRepository(db),
-					new TransactionRepository(db),
+					new TransactionRepository(db, userId),
 					api,
-					new CategoryRepository(db),
+					new CategoryRepository(db, userId),
 				).sendMessageAndApplyActions({
 					threadId: threadId,
 					userText: trimmed,
@@ -76,7 +78,7 @@ const AiChatView = ({
 				setIsAwaitingAiResponse(false);
 			}
 		}
-	}, [text, backendStatus, isAwaitingAiResponse, threadId, db, api]);
+	}, [text, backendStatus, isAwaitingAiResponse, threadId, db, api, userId]);
 
 	const contentView = useMemo(() => {
 		if (!threadId) {

--- a/src/screens/HomeScreen/AiChatView.tsx
+++ b/src/screens/HomeScreen/AiChatView.tsx
@@ -59,7 +59,7 @@ const AiChatView = ({
 
 				await new AIActionHandler(
 					new AIConversationRepository(db),
-					new TransactionRepository(db, userId),
+					new TransactionRepository(db, userId, api),
 					api,
 					new CategoryRepository(db, userId),
 				).sendMessageAndApplyActions({
@@ -78,7 +78,15 @@ const AiChatView = ({
 				setIsAwaitingAiResponse(false);
 			}
 		}
-	}, [text, backendStatus, isAwaitingAiResponse, threadId, db, api, userId]);
+	}, [
+		text,
+		backendStatus,
+		isAwaitingAiResponse,
+		threadId,
+		db,
+		api,
+		userId,
+	]);
 
 	const contentView = useMemo(() => {
 		if (!threadId) {

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -117,11 +117,7 @@ const HomeScreen = (_props: Props) => {
 						style: 'destructive',
 						onPress: async () => {
 							await new DeleteTransaction(
-								new TransactionRepository(
-									db,
-									userId,
-									api,
-								),
+								new TransactionRepository(db, userId, api),
 							).execute(transactionId);
 						},
 					},

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -12,6 +12,7 @@ import {
 	AppStackParamList,
 	AppStackScreens,
 } from '@navigation/AppStack/AppStack';
+import { useApiClient } from '@providers/ApiClientProvider';
 import { useAuthStore } from '@providers/AuthProvider';
 import { useDatabase } from '@providers/DatabaseProvider';
 import { useTheme } from '@providers/ThemeProvider';
@@ -47,7 +48,8 @@ type Props = NativeStackScreenProps<
 
 const HomeScreen = (_props: Props) => {
 	// hooks
-	const { logout } = useAuthStore();
+	const { logout, userId } = useAuthStore();
+	const { api } = useApiClient();
 	const { colors } = useTheme();
 	const styles = useMemo(() => createStyles(colors), [colors]);
 	const { db } = useDatabase();
@@ -56,7 +58,7 @@ const HomeScreen = (_props: Props) => {
 		db,
 		threadId,
 	);
-	const transactions = useReactiveTransactions(db);
+	const transactions = useReactiveTransactions(db, userId);
 	const [activeView, setActiveView] = useState<'chat' | 'transactions'>(
 		'chat',
 	);
@@ -76,6 +78,7 @@ const HomeScreen = (_props: Props) => {
 	const tableTransactions = useMemo(() => {
 		return transactions.map((transaction) => ({
 			...transaction,
+			ownerId: transaction.ownerId ?? null,
 			id: transaction.id,
 			name: transaction.merchant || 'Transaction',
 			amount: transaction.amount,
@@ -114,14 +117,18 @@ const HomeScreen = (_props: Props) => {
 						style: 'destructive',
 						onPress: async () => {
 							await new DeleteTransaction(
-								new TransactionRepository(db),
+								new TransactionRepository(
+									db,
+									userId,
+									api,
+								),
 							).execute(transactionId);
 						},
 					},
 				],
 			);
 		},
-		[db],
+		[api, db, userId],
 	);
 
 	// side effects

--- a/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
+++ b/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
@@ -77,7 +77,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 
 		const ensureDefaultAccount = async () => {
 			const useCase = new EnsureDefaultAccount(
-				new AccountRepository(db, userId),
+				new AccountRepository(db, userId, api),
 			);
 			await useCase.execute();
 		};
@@ -86,7 +86,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 			console.error('Failed to load accounts', error);
 			setErrorMessage('Unable to load accounts.');
 		});
-	}, [db, userId]);
+	}, [api, db, userId]);
 
 	useEffect(() => {
 		if (!db) {
@@ -99,6 +99,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 				const loadedCategories = await new CategoryRepository(
 					db,
 					userId,
+					api,
 				).list();
 				setCategories(loadedCategories);
 			} catch (error) {
@@ -107,7 +108,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		};
 
 		loadCategories();
-	}, [db, userId]);
+	}, [api, db, userId]);
 
 	useEffect(() => {
 		if (!accounts.length) {
@@ -138,7 +139,11 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		try {
 			const normalizedCategory = category.trim();
 			if (normalizedCategory) {
-				const categoryRepo = new CategoryRepository(db, userId);
+				const categoryRepo = new CategoryRepository(
+					db,
+					userId,
+					api,
+				);
 				const hasCategory = (await categoryRepo.list()).some(
 					(existingCategory) =>
 						existingCategory.name.toLowerCase() ===

--- a/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
+++ b/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
@@ -7,6 +7,7 @@ import {
 	AppStackScreens,
 } from '@navigation/AppStack/AppStack';
 import { useDatabase } from '@providers/DatabaseProvider';
+import { useAuthStore } from '@providers/AuthProvider';
 import { useTheme } from '@providers/ThemeProvider';
 import { AccountRepository } from '@repositories/AccountRepository';
 import { CategoryRepository } from '@repositories/CategoryRepository';
@@ -44,6 +45,7 @@ const toDateInputValue = (date = new Date()) => {
 
 const ManualTransactionScreen = ({ navigation }: Props) => {
 	const { db } = useDatabase();
+	const { userId } = useAuthStore();
 	const { colors, isDarkMode } = useTheme();
 	const styles = useMemo(() => createStyles(colors), [colors]);
 	const { keyboardShift, dismissKeyboardOnTouchCapture } =
@@ -73,7 +75,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 
 		const ensureDefaultAccount = async () => {
 			const useCase = new EnsureDefaultAccount(
-				new AccountRepository(db),
+				new AccountRepository(db, userId),
 			);
 			await useCase.execute();
 		};
@@ -82,7 +84,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 			console.error('Failed to load accounts', error);
 			setErrorMessage('Unable to load accounts.');
 		});
-	}, [db]);
+	}, [db, userId]);
 
 	useEffect(() => {
 		if (!db) {
@@ -94,6 +96,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 			try {
 				const loadedCategories = await new CategoryRepository(
 					db,
+					userId,
 				).list();
 				setCategories(loadedCategories);
 			} catch (error) {
@@ -102,7 +105,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		};
 
 		loadCategories();
-	}, [db]);
+	}, [db, userId]);
 
 	useEffect(() => {
 		if (!accounts.length) {
@@ -133,7 +136,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		try {
 			const normalizedCategory = category.trim();
 			if (normalizedCategory) {
-				const categoryRepo = new CategoryRepository(db);
+				const categoryRepo = new CategoryRepository(db, userId);
 				const hasCategory = (await categoryRepo.list()).some(
 					(existingCategory) =>
 						existingCategory.name.toLowerCase() ===
@@ -148,7 +151,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 			}
 
 			const useCase = new CreateManualTransaction(
-				new TransactionRepository(db),
+				new TransactionRepository(db, userId),
 			);
 			const result = await useCase.execute({
 				amount,
@@ -184,6 +187,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		navigation,
 		selectedAccountId,
 		transactionType,
+		userId,
 	]);
 
 	if (!db) {

--- a/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
+++ b/src/screens/ManualTransactionScreen/ManualTransactionScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from '@navigation/AppStack/AppStack';
 import { useDatabase } from '@providers/DatabaseProvider';
 import { useAuthStore } from '@providers/AuthProvider';
+import { useApiClient } from '@providers/ApiClientProvider';
 import { useTheme } from '@providers/ThemeProvider';
 import { AccountRepository } from '@repositories/AccountRepository';
 import { CategoryRepository } from '@repositories/CategoryRepository';
@@ -46,6 +47,7 @@ const toDateInputValue = (date = new Date()) => {
 const ManualTransactionScreen = ({ navigation }: Props) => {
 	const { db } = useDatabase();
 	const { userId } = useAuthStore();
+	const { api } = useApiClient();
 	const { colors, isDarkMode } = useTheme();
 	const styles = useMemo(() => createStyles(colors), [colors]);
 	const { keyboardShift, dismissKeyboardOnTouchCapture } =
@@ -66,7 +68,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 	const [categories, setCategories] = useState<Category[]>([]);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [isSaving, setIsSaving] = useState(false);
-	const accounts = useReactiveAccounts(db);
+	const accounts = useReactiveAccounts(db, userId);
 
 	useEffect(() => {
 		if (!db) {
@@ -151,7 +153,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 			}
 
 			const useCase = new CreateManualTransaction(
-				new TransactionRepository(db, userId),
+				new TransactionRepository(db, userId, api),
 			);
 			const result = await useCase.execute({
 				amount,
@@ -182,6 +184,7 @@ const ManualTransactionScreen = ({ navigation }: Props) => {
 		category,
 		date,
 		db,
+		api,
 		isSaving,
 		merchant,
 		navigation,

--- a/src/screens/SettingsScreen/SettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.test.tsx
@@ -1,4 +1,5 @@
 import { useAuthStore } from '@providers/AuthProvider';
+import { useApiClient } from '@providers/ApiClientProvider';
 import { DatabaseProvider } from '@providers/DatabaseProvider';
 import { ThemeProvider } from '@providers/ThemeProvider';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -8,6 +9,10 @@ import SettingsScreen from './SettingsScreen';
 
 jest.mock('@providers/AuthProvider', () => ({
 	useAuthStore: jest.fn(),
+}));
+
+jest.mock('@providers/ApiClientProvider', () => ({
+	useApiClient: jest.fn(),
 }));
 
 jest.mock('@providers/DatabaseProvider', () => ({
@@ -43,6 +48,15 @@ describe('SettingsScreen', () => {
 
 		(useAuthStore as jest.Mock).mockReturnValue({
 			logout: jest.fn(),
+			userId: 'auth0|test-user',
+		});
+
+		(useApiClient as jest.Mock).mockReturnValue({
+			api: {
+				transactions: {
+					clear: jest.fn(),
+				},
+			},
 		});
 	});
 

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import { TestID } from '@enums/TestID';
 import { AppStackScreens } from '@navigation/AppStack/AppStack';
 import { NavigationService } from '@navigation/navigationService';
 import { useAuthStore } from '@providers/AuthProvider';
+import { useApiClient } from '@providers/ApiClientProvider';
 import { useDatabase } from '@providers/DatabaseProvider';
 import { useTheme } from '@providers/ThemeProvider';
 import { AccountRepository } from '@repositories/AccountRepository';
@@ -184,13 +185,14 @@ const SettingsSwitches = ({
 };
 
 const SettingsScreen = () => {
-	const { logout } = useAuthStore();
+	const { logout, userId } = useAuthStore();
+	const { api } = useApiClient();
 	const { db } = useDatabase();
 	const { colors } = useTheme();
 	const styles = useMemo(() => createStyles(colors), [colors]);
 
 	const clearTransactions = useCallback(() => {
-		if (!db) {
+		if (!db || !userId) {
 			return;
 		}
 
@@ -204,13 +206,13 @@ const SettingsScreen = () => {
 					style: 'destructive',
 					onPress: async () => {
 						await new ClearTransactions(
-							new TransactionRepository(db),
+							new TransactionRepository(db, userId, api),
 						).execute();
 					},
 				},
 			],
 		);
-	}, [db]);
+	}, [api, db, userId]);
 
 	const clearAccounts = useCallback(() => {
 		if (!db) {

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -229,13 +229,13 @@ const SettingsScreen = () => {
 					style: 'destructive',
 					onPress: async () => {
 						await new ClearAccounts(
-							new AccountRepository(db),
+							new AccountRepository(db, userId, api),
 						).execute();
 					},
 				},
 			],
 		);
-	}, [db]);
+	}, [api, db, userId]);
 
 	const clearBudgets = useCallback(() => {
 		if (!db) {
@@ -252,13 +252,13 @@ const SettingsScreen = () => {
 					style: 'destructive',
 					onPress: async () => {
 						await new ClearBudgets(
-							new BudgetRepository(db),
+							new BudgetRepository(db, userId, api),
 						).execute();
 					},
 				},
 			],
 		);
-	}, [db]);
+	}, [api, db, userId]);
 
 	const clearCategories = useCallback(() => {
 		if (!db) {
@@ -275,13 +275,13 @@ const SettingsScreen = () => {
 					style: 'destructive',
 					onPress: async () => {
 						await new ClearCategories(
-							new CategoryRepository(db),
+							new CategoryRepository(db, userId, api),
 						).execute();
 					},
 				},
 			],
 		);
-	}, [db]);
+	}, [api, db, userId]);
 
 	return (
 		<ThemedScreen>

--- a/src/services/ApiClient.test.ts
+++ b/src/services/ApiClient.test.ts
@@ -62,6 +62,13 @@ function makeAxiosErrorWithErrorField(status: number, error: string) {
 	return err;
 }
 
+function makeAxiosErrorWithObjectMessage(status: number, message: unknown) {
+	const err = new Error('Bad Request') as any;
+	err.response = { status, data: { message } };
+	(axios.isAxiosError as unknown as jest.Mock).mockReturnValueOnce(true);
+	return err;
+}
+
 // ── health.check ────────────────────────────────────────────────────────────
 
 describe('apiClient.health.check', () => {
@@ -223,6 +230,23 @@ describe('apiClient.plaid.exchangePublicToken', () => {
 		).rejects.toMatchObject<Partial<ApiError>>({
 			status: 400,
 			message: 'Missing publicToken in request body',
+		});
+	});
+
+	it('normalizes backend payloads where message is an object', async () => {
+		mockAxiosInstance.post.mockRejectedValueOnce(
+			makeAxiosErrorWithObjectMessage(400, {
+				error: 'Validation failed: amount must be positive',
+			}),
+		);
+
+		await expect(
+			apiClient.plaid.exchangePublicToken({
+				publicToken: '',
+			}),
+		).rejects.toMatchObject<Partial<ApiError>>({
+			status: 400,
+			message: 'Validation failed: amount must be positive',
 		});
 	});
 

--- a/src/services/ApiClient.ts
+++ b/src/services/ApiClient.ts
@@ -240,12 +240,86 @@ export class ApiClient extends BaseService {
 			this.request(() =>
 				this.http.get<{ data: unknown[] }>('/budgets', { signal }),
 			),
+		create: (
+			body: {
+				id?: string;
+				name: string;
+				amount: number;
+				categoryId?: string | null;
+				periodStart: string;
+				periodEnd: string;
+				createdAt?: string;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.post('/budgets', body, { signal }),
+			),
+		update: (
+			id: string,
+			body: {
+				name?: string;
+				amount?: number;
+				categoryId?: string | null;
+				periodStart?: string;
+				periodEnd?: string;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.put(`/budgets/${id}`, body, { signal }),
+			),
+		delete: (id: string, signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete(`/budgets/${id}`, { signal }),
+			),
+		clear: (signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete('/budgets/all', { signal }),
+			),
 	};
 
 	readonly accounts = {
 		list: (signal?: AbortSignal): Promise<{ data: unknown[] }> =>
 			this.request(() =>
 				this.http.get<{ data: unknown[] }>('/accounts', { signal }),
+			),
+		create: (
+			body: {
+				id?: string;
+				name: string;
+				accountType: string;
+				currency: string;
+				createdAt?: string;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.post('/accounts', body, { signal }),
+			),
+		update: (
+			id: string,
+			body: {
+				name?: string;
+				accountType?: string;
+				currency?: string;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.put(`/accounts/${id}`, body, { signal }),
+			),
+		delete: (id: string, signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete(`/accounts/${id}`, { signal }),
+			),
+		clear: (signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete('/accounts/all', { signal }),
 			),
 	};
 
@@ -255,6 +329,41 @@ export class ApiClient extends BaseService {
 				this.http.get<{ data: unknown[] }>('/categories', {
 					signal,
 				}),
+			),
+		create: (
+			body: {
+				id?: string;
+				name: string;
+				color?: string | null;
+				icon?: string | null;
+				createdAt?: string;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.post('/categories', body, { signal }),
+			),
+		update: (
+			id: string,
+			body: {
+				name?: string;
+				color?: string | null;
+				icon?: string | null;
+				updatedAt?: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.put(`/categories/${id}`, body, { signal }),
+			),
+		delete: (id: string, signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete(`/categories/${id}`, { signal }),
+			),
+		clear: (signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete('/categories/all', { signal }),
 			),
 	};
 }

--- a/src/services/ApiClient.ts
+++ b/src/services/ApiClient.ts
@@ -33,17 +33,51 @@ export interface HealthCheckResponse {
 	status: string;
 }
 
+function toReadableErrorMessage(value: unknown): string | null {
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed ? trimmed : null;
+	}
+
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+
+	if (!value || typeof value !== 'object') {
+		return null;
+	}
+
+	const record = value as Record<string, unknown>;
+	const nested =
+		toReadableErrorMessage(record.message) ??
+		toReadableErrorMessage(record.error) ??
+		toReadableErrorMessage(record.detail) ??
+		toReadableErrorMessage(record.details);
+
+	if (nested) {
+		return nested;
+	}
+
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return null;
+	}
+}
+
 function normalizeError(err: unknown): ApiError {
 	if (err instanceof CanceledError) {
 		return { status: 0, message: 'Request cancelled', cause: err };
 	}
 	if (axios.isAxiosError(err)) {
-		const data = err.response?.data as
-			| { message?: string; error?: string }
-			| undefined;
+		const message =
+			toReadableErrorMessage(err.response?.data) ??
+			toReadableErrorMessage(err.message) ??
+			'Request failed';
+
 		return {
 			status: err.response?.status ?? 0,
-			message: data?.message ?? data?.error ?? err.message,
+			message,
 			cause: err,
 		};
 	}
@@ -52,6 +86,7 @@ function normalizeError(err: unknown): ApiError {
 
 class BaseService {
 	protected readonly http: AxiosInstance;
+	private authToken: string | null = null;
 
 	constructor(baseUrl: string) {
 		this.http = axios.create({
@@ -61,10 +96,16 @@ class BaseService {
 
 		this.http.interceptors.request.use(
 			(config: InternalAxiosRequestConfig) => {
-				// TODO: Attach auth token dynamically
+				if (this.authToken) {
+					config.headers.Authorization = `Bearer ${this.authToken}`;
+				}
 				return config;
 			},
 		);
+	}
+
+	setAuthToken(token: string | null): void {
+		this.authToken = token;
 	}
 
 	protected async request<T>(
@@ -135,6 +176,85 @@ export class ApiClient extends BaseService {
 					{ messages },
 					{ signal },
 				),
+			),
+	};
+
+	readonly transactions = {
+		list: (signal?: AbortSignal): Promise<{ data: unknown[] }> =>
+			this.request(() =>
+				this.http.get<{ data: unknown[] }>('/transactions', {
+					signal,
+				}),
+			),
+		create: (
+			body: {
+				id?: string;
+				accountId?: string | null;
+				amount: number;
+				merchant?: string | null;
+				category?: string | null;
+				transactionType: 'expense' | 'income' | 'transfer';
+				date: string;
+				source: 'manual' | 'ai';
+				createdAt: string;
+			},
+			signal?: AbortSignal,
+		): Promise<unknown> =>
+			this.request(() =>
+				this.http.post('/transactions', body, { signal }),
+			),
+		clear: (signal?: AbortSignal): Promise<unknown> =>
+			this.request(() =>
+				this.http.delete('/transactions/all', { signal }),
+			),
+		delete: async (
+			id: string,
+			signal?: AbortSignal,
+		): Promise<unknown> => {
+			try {
+				return await this.request(() =>
+					this.http.delete(`/transactions/${id}`, {
+						signal,
+					}),
+				);
+			} catch (error) {
+				const apiError = error as ApiError;
+				if (apiError.status !== 404) {
+					throw error;
+				}
+
+				return this.request(() =>
+					this.http.delete('/transactions', {
+						signal,
+						params: {
+							id,
+						},
+					}),
+				);
+			}
+		},
+	};
+
+	readonly budgets = {
+		list: (signal?: AbortSignal): Promise<{ data: unknown[] }> =>
+			this.request(() =>
+				this.http.get<{ data: unknown[] }>('/budgets', { signal }),
+			),
+	};
+
+	readonly accounts = {
+		list: (signal?: AbortSignal): Promise<{ data: unknown[] }> =>
+			this.request(() =>
+				this.http.get<{ data: unknown[] }>('/accounts', { signal }),
+			),
+	};
+
+	readonly categories = {
+		list: (signal?: AbortSignal): Promise<{ data: unknown[] }> =>
+			this.request(() =>
+				this.http.get<{ data: unknown[] }>('/categories', {
+					signal,
+				}),
 			),
 	};
 }

--- a/src/services/Auth0Service.ts
+++ b/src/services/Auth0Service.ts
@@ -1,4 +1,5 @@
 import Auth0 from 'react-native-auth0';
+import { parseJwtUserId } from '@utils/jwtUtils';
 
 type Auth0Config = {
 	domain: string;
@@ -11,7 +12,7 @@ const AUTH0_CONFIG: Auth0Config = {
 };
 
 export type AuthService = {
-	login: () => Promise<string>;
+	login: () => Promise<{ token: string; userId: string }>;
 	logout: () => Promise<void>;
 };
 
@@ -47,7 +48,7 @@ export class Auth0Service implements AuthService {
 		}
 	}
 
-	async login(): Promise<string> {
+	async login(): Promise<{ token: string; userId: string }> {
 		this.assertConfigured();
 
 		const credentials = await this.client.webAuth.authorize({
@@ -56,14 +57,31 @@ export class Auth0Service implements AuthService {
 
 		await this.client.credentialsManager.saveCredentials(credentials);
 
-		const token = credentials.accessToken ?? credentials.idToken;
+		const token = credentials.idToken ?? credentials.accessToken;
 		if (!token) {
 			throw new Error(
 				'Auth0 login succeeded but no token was returned.',
 			);
 		}
 
-		return token;
+		let userId = parseJwtUserId(credentials.idToken ?? null);
+
+		if (!userId && credentials.accessToken) {
+			const profile = await this.client.auth.userInfo({
+				token: credentials.accessToken,
+			});
+			if (profile?.sub) {
+				userId = String(profile.sub);
+			}
+		}
+
+		if (!userId) {
+			throw new Error(
+				'Auth0 login succeeded but user id (sub) was not available.',
+			);
+		}
+
+		return { token, userId };
 	}
 
 	async logout(): Promise<void> {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -1,0 +1,650 @@
+import { executeTransaction } from '@db/executeTransaction';
+import { notifyTableChanged } from '@db/databaseChangeNotifier';
+import { DB } from '@op-engineering/op-sqlite';
+import { ApiClient, type ApiError } from '@services/ApiClient';
+import { nowIso } from '@utils/dateUtil';
+
+type UnknownRecord = Record<string, unknown>;
+type SyncResource = 'transactions' | 'budgets' | 'accounts' | 'categories';
+
+type SyncedTransaction = {
+	id: string;
+	ownerId: string;
+	accountId: string | null;
+	amount: number;
+	merchant: string | null;
+	category: string | null;
+	transactionType: 'expense' | 'income' | 'transfer';
+	date: string;
+	createdAt: string;
+	source: 'manual' | 'ai';
+	syncStatus: 'synced';
+};
+
+type SyncedAccount = {
+	id: string;
+	ownerId: string;
+	name: string;
+	accountType: string;
+	currency: string;
+	createdAt: string;
+	updatedAt: string;
+};
+
+type SyncedCategory = {
+	id: string;
+	ownerId: string;
+	name: string;
+	color: string | null;
+	icon: string | null;
+	createdAt: string;
+	updatedAt: string;
+};
+
+type SyncedBudget = {
+	id: string;
+	ownerId: string;
+	name: string;
+	amount: number;
+	categoryId: string | null;
+	periodStart: string;
+	periodEnd: string;
+	createdAt: string;
+	updatedAt: string;
+};
+
+type PendingTransactionRow = {
+	id: string;
+	owner_id: string | null;
+	account_id: string | null;
+	amount: number;
+	merchant: string | null;
+	category: string | null;
+	transaction_type: 'expense' | 'income' | 'transfer';
+	date: string;
+	created_at: string;
+	source: 'manual' | 'ai' | string | null;
+	sync_status: string | null;
+};
+
+function asObject(input: unknown): UnknownRecord {
+	return typeof input === 'object' && input !== null
+		? (input as UnknownRecord)
+		: {};
+}
+
+function asString(value: unknown, fallback = ''): string {
+	if (typeof value === 'string') {
+		return value;
+	}
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	return fallback;
+}
+
+function asNullableString(value: unknown): string | null {
+	const normalized = asString(value).trim();
+	return normalized ? normalized : null;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+	if (typeof value === 'string') {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+	return fallback;
+}
+
+function asArray(payload: unknown): unknown[] {
+	if (Array.isArray(payload)) {
+		return payload;
+	}
+	const obj = asObject(payload);
+	if (Array.isArray(obj.data)) {
+		return obj.data;
+	}
+	if (Array.isArray(obj.items)) {
+		return obj.items;
+	}
+	return [];
+}
+
+function isDuplicateTransactionIdError(error: ApiError | undefined): boolean {
+	if (!error) {
+		return false;
+	}
+
+	if (error.status === 409) {
+		return true;
+	}
+
+	const message = (error.message ?? '').toLowerCase();
+	return (
+		error.status === 400 &&
+		message.includes('unique constraint failed') &&
+		message.includes('transactions.id')
+	);
+}
+
+async function fetchCollectionOrEmpty(
+	resourceName: SyncResource,
+	fetcher: (signal?: AbortSignal) => Promise<unknown>,
+	signal?: AbortSignal,
+): Promise<unknown[]> {
+	try {
+		const payload = await fetcher(signal);
+		return asArray(payload);
+	} catch (error) {
+		const apiError = error as ApiError;
+
+		if (apiError?.status === 404) {
+			console.warn(
+				`[SyncService] Skipping ${resourceName} sync because endpoint returned 404`,
+			);
+			return [];
+		}
+
+		throw error;
+	}
+}
+
+async function fetchOptionalCollection(
+	resourceName: Exclude<SyncResource, 'transactions'>,
+	fetcher: (signal?: AbortSignal) => Promise<unknown>,
+	signal?: AbortSignal,
+): Promise<unknown[]> {
+	try {
+		const payload = await fetcher(signal);
+		return asArray(payload);
+	} catch (error) {
+		const apiError = error as ApiError;
+		const statusCode = apiError?.status ?? 0;
+		const message = apiError?.message ?? 'Unknown error';
+
+		console.warn(
+			`[SyncService] Skipping ${resourceName} sync (${statusCode}): ${message}`,
+		);
+		return [];
+	}
+}
+
+function normalizeTransaction(
+	input: unknown,
+	ownerId: string,
+): SyncedTransaction | null {
+	const row = asObject(input);
+	const id = asString(row.id || row.transactionId).trim();
+	if (!id) {
+		return null;
+	}
+
+	const transactionTypeValue = asString(
+		row.transactionType ?? row.transaction_type,
+		'expense',
+	);
+	const transactionType: SyncedTransaction['transactionType'] =
+		transactionTypeValue === 'income' ||
+		transactionTypeValue === 'transfer'
+			? transactionTypeValue
+			: 'expense';
+
+	const sourceValue = asString(row.source, 'manual');
+	const source: SyncedTransaction['source'] =
+		sourceValue === 'ai' ? 'ai' : 'manual';
+
+	const createdAt = asString(row.createdAt ?? row.created_at, nowIso());
+	const date = asString(row.date, createdAt);
+
+	return {
+		id,
+		ownerId,
+		accountId: asNullableString(row.accountId ?? row.account_id),
+		amount: Math.abs(asNumber(row.amount, 0)),
+		merchant: asNullableString(row.merchant),
+		category: asNullableString(row.category),
+		transactionType,
+		date,
+		createdAt,
+		source,
+		syncStatus: 'synced',
+	};
+}
+
+function normalizeAccount(
+	input: unknown,
+	ownerId: string,
+): SyncedAccount | null {
+	const row = asObject(input);
+	const id = asString(row.id || row.accountId).trim();
+	if (!id) {
+		return null;
+	}
+
+	const now = nowIso();
+	return {
+		id,
+		ownerId,
+		name: asString(row.name, 'Account').trim() || 'Account',
+		accountType: asString(row.accountType ?? row.account_type, 'cash'),
+		currency: asString(row.currency, 'USD'),
+		createdAt: asString(row.createdAt ?? row.created_at, now),
+		updatedAt: asString(row.updatedAt ?? row.updated_at, now),
+	};
+}
+
+function normalizeCategory(
+	input: unknown,
+	ownerId: string,
+): SyncedCategory | null {
+	const row = asObject(input);
+	const id = asString(row.id || row.categoryId).trim();
+	if (!id) {
+		return null;
+	}
+
+	const now = nowIso();
+	return {
+		id,
+		ownerId,
+		name: asString(row.name, 'Category').trim() || 'Category',
+		color: asNullableString(row.color),
+		icon: asNullableString(row.icon),
+		createdAt: asString(row.createdAt ?? row.created_at, now),
+		updatedAt: asString(row.updatedAt ?? row.updated_at, now),
+	};
+}
+
+function normalizeBudget(
+	input: unknown,
+	ownerId: string,
+): SyncedBudget | null {
+	const row = asObject(input);
+	const id = asString(row.id || row.budgetId).trim();
+	if (!id) {
+		return null;
+	}
+
+	const now = nowIso();
+	const createdAt = asString(row.createdAt ?? row.created_at, now);
+	const updatedAt = asString(row.updatedAt ?? row.updated_at, createdAt);
+	const periodStart = asString(
+		row.periodStart ?? row.period_start,
+		createdAt.slice(0, 10),
+	);
+	const periodEnd = asString(
+		row.periodEnd ?? row.period_end,
+		periodStart,
+	);
+
+	return {
+		id,
+		ownerId,
+		name: asString(row.name, 'Budget').trim() || 'Budget',
+		amount: Math.abs(asNumber(row.amount, 0)),
+		categoryId: asNullableString(row.categoryId ?? row.category_id),
+		periodStart,
+		periodEnd,
+		createdAt,
+		updatedAt,
+	};
+}
+
+async function mergeOwnerTransactions(
+	db: DB,
+	rows: SyncedTransaction[],
+): Promise<void> {
+	if (!rows.length) {
+		return;
+	}
+
+	await executeTransaction(db, [
+		...rows.map((row) => ({
+			sql: `
+				INSERT OR REPLACE INTO transactions (
+					id,
+					owner_id,
+					account_id,
+					amount,
+					merchant,
+					category,
+					transaction_type,
+					date,
+					created_at,
+					sync_status,
+					source
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`,
+			args: [
+				row.id,
+				row.ownerId,
+				row.accountId,
+				row.amount,
+				row.merchant,
+				row.category,
+				row.transactionType,
+				row.date,
+				row.createdAt,
+				row.syncStatus,
+				row.source,
+			],
+		})),
+	]);
+}
+
+async function mergeOwnerAccounts(
+	db: DB,
+	rows: SyncedAccount[],
+): Promise<void> {
+	if (!rows.length) {
+		return;
+	}
+
+	await executeTransaction(db, [
+		...rows.map((row) => ({
+			sql: `
+				INSERT OR REPLACE INTO accounts (
+					id,
+					owner_id,
+					name,
+					account_type,
+					currency,
+					created_at,
+					updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`,
+			args: [
+				row.id,
+				row.ownerId,
+				row.name,
+				row.accountType,
+				row.currency,
+				row.createdAt,
+				row.updatedAt,
+			],
+		})),
+	]);
+}
+
+async function mergeOwnerCategories(
+	db: DB,
+	rows: SyncedCategory[],
+): Promise<void> {
+	if (!rows.length) {
+		return;
+	}
+
+	await executeTransaction(db, [
+		...rows.map((row) => ({
+			sql: `
+				INSERT OR REPLACE INTO categories (
+					id,
+					owner_id,
+					name,
+					color,
+					icon,
+					created_at,
+					updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`,
+			args: [
+				row.id,
+				row.ownerId,
+				row.name,
+				row.color,
+				row.icon,
+				row.createdAt,
+				row.updatedAt,
+			],
+		})),
+	]);
+}
+
+async function mergeOwnerBudgets(
+	db: DB,
+	rows: SyncedBudget[],
+): Promise<void> {
+	if (!rows.length) {
+		return;
+	}
+
+	await executeTransaction(db, [
+		...rows.map((row) => ({
+			sql: `
+				INSERT OR REPLACE INTO budgets (
+					id,
+					owner_id,
+					name,
+					amount,
+					category_id,
+					period_start,
+					period_end,
+					created_at,
+					updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`,
+			args: [
+				row.id,
+				row.ownerId,
+				row.name,
+				row.amount,
+				row.categoryId,
+				row.periodStart,
+				row.periodEnd,
+				row.createdAt,
+				row.updatedAt,
+			],
+		})),
+	]);
+}
+
+export class SyncService {
+	private static didLogEndpointProbe = false;
+
+	constructor(private readonly db: DB, private readonly api: ApiClient) {}
+
+	private async getPendingTransactions(
+		ownerId: string,
+	): Promise<PendingTransactionRow[]> {
+		const result = await this.db.execute(
+			`
+			SELECT
+				id,
+				owner_id,
+				account_id,
+				amount,
+				merchant,
+				category,
+				transaction_type,
+				date,
+				created_at,
+				source,
+				sync_status
+			FROM transactions
+			WHERE owner_id = ?
+				AND (sync_status = 'pending' OR sync_status IS NULL)
+			ORDER BY created_at ASC
+		`,
+			[ownerId],
+		);
+
+		return result.rows as PendingTransactionRow[];
+	}
+
+	private async markTransactionsSynced(
+		transactionIds: string[],
+	): Promise<void> {
+		if (!transactionIds.length) {
+			return;
+		}
+
+		await executeTransaction(
+			this.db,
+			transactionIds.map((id) => ({
+				sql: 'UPDATE transactions SET sync_status = ? WHERE id = ?',
+				args: ['synced', id],
+			})),
+		);
+	}
+
+	private async pushPendingTransactions(
+		ownerId: string,
+		signal?: AbortSignal,
+	): Promise<void> {
+		const pending = await this.getPendingTransactions(ownerId);
+		if (!pending.length) {
+			return;
+		}
+
+		const syncedIds: string[] = [];
+
+		for (const row of pending) {
+			try {
+				await this.api.transactions.create(
+					{
+						id: String(row.id),
+						accountId: row.account_id
+							? String(row.account_id)
+							: null,
+						amount: Math.abs(Number(row.amount)),
+						merchant: row.merchant
+							? String(row.merchant)
+							: null,
+						category: row.category
+							? String(row.category)
+							: null,
+						transactionType: row.transaction_type,
+						date: String(row.date),
+						source: row.source === 'ai' ? 'ai' : 'manual',
+						createdAt: String(row.created_at),
+					},
+					signal,
+				);
+				syncedIds.push(String(row.id));
+			} catch (error) {
+				const apiError = error as ApiError;
+				if (isDuplicateTransactionIdError(apiError)) {
+					// If server already has this id, treat as synced.
+					syncedIds.push(String(row.id));
+					continue;
+				}
+
+				console.warn(
+					`[SyncService] Failed to push transaction ${String(
+						row.id,
+					)} (${apiError?.status ?? 0}): ${
+						apiError?.message ?? 'Unknown error'
+					}`,
+				);
+			}
+		}
+
+		await this.markTransactionsSynced(syncedIds);
+	}
+
+	private getResourceFetchers(): Array<{
+		name: SyncResource;
+		fetcher: (signal?: AbortSignal) => Promise<unknown>;
+	}> {
+		return [
+			{ name: 'transactions', fetcher: this.api.transactions.list },
+			{ name: 'budgets', fetcher: this.api.budgets.list },
+			{ name: 'accounts', fetcher: this.api.accounts.list },
+			{ name: 'categories', fetcher: this.api.categories.list },
+		];
+	}
+
+	async probeEndpointAvailability(signal?: AbortSignal): Promise<void> {
+		if (SyncService.didLogEndpointProbe) {
+			return;
+		}
+
+		const resources = this.getResourceFetchers();
+		const checks = await Promise.allSettled(
+			resources.map(async ({ name, fetcher }) => {
+				await fetcher(signal);
+				return { name, status: 'ok' as const };
+			}),
+		);
+
+		const summary = checks.map((check, index) => {
+			const name = resources[index].name;
+			if (check.status === 'fulfilled') {
+				return `${name}:ok`;
+			}
+
+			const apiError = check.reason as ApiError;
+			const statusCode = apiError?.status ?? 0;
+			return `${name}:${statusCode}`;
+		});
+
+		console.info(`[SyncService] Endpoint probe ${summary.join(', ')}`);
+		SyncService.didLogEndpointProbe = true;
+	}
+
+	async pullOwnerData(
+		ownerId: string,
+		signal?: AbortSignal,
+	): Promise<void> {
+		await this.pushPendingTransactions(ownerId, signal);
+
+		const resources = this.getResourceFetchers();
+		const transactionsResponse = await fetchCollectionOrEmpty(
+			'transactions',
+			resources[0].fetcher,
+			signal,
+		);
+
+		const [budgetsResponse, accountsResponse, categoriesResponse] =
+			await Promise.all([
+				fetchOptionalCollection(
+					'budgets',
+					resources[1].fetcher,
+					signal,
+				),
+				fetchOptionalCollection(
+					'accounts',
+					resources[2].fetcher,
+					signal,
+				),
+				fetchOptionalCollection(
+					'categories',
+					resources[3].fetcher,
+					signal,
+				),
+			]);
+
+		const transactions = transactionsResponse
+			.map((row) => normalizeTransaction(row, ownerId))
+			.filter((row): row is SyncedTransaction => Boolean(row));
+		const budgets = budgetsResponse
+			.map((row) => normalizeBudget(row, ownerId))
+			.filter((row): row is SyncedBudget => Boolean(row));
+		const accounts = accountsResponse
+			.map((row) => normalizeAccount(row, ownerId))
+			.filter((row): row is SyncedAccount => Boolean(row));
+		const categories = categoriesResponse
+			.map((row) => normalizeCategory(row, ownerId))
+			.filter((row): row is SyncedCategory => Boolean(row));
+
+		// Offline-first merge strategy: upsert remote rows and never delete local rows on pull.
+		await mergeOwnerAccounts(this.db, accounts);
+		await mergeOwnerCategories(this.db, categories);
+		await mergeOwnerBudgets(this.db, budgets);
+		await mergeOwnerTransactions(this.db, transactions);
+
+		notifyTableChanged('accounts');
+		notifyTableChanged('categories');
+		notifyTableChanged('budgets');
+		notifyTableChanged('transactions');
+	}
+}

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -115,7 +115,9 @@ function asArray(payload: unknown): unknown[] {
 	return [];
 }
 
-function isDuplicateTransactionIdError(error: ApiError | undefined): boolean {
+function isDuplicateTransactionIdError(
+	error: ApiError | undefined,
+): boolean {
 	if (!error) {
 		return false;
 	}

--- a/src/stores/AuthStore.test.ts
+++ b/src/stores/AuthStore.test.ts
@@ -3,7 +3,9 @@ import { StorageService } from '@services/StorageService';
 import { act } from '@testing-library/react-native';
 
 const mockAuthService = {
-	login: jest.fn().mockResolvedValue('auth0-token'),
+	login: jest
+		.fn()
+		.mockResolvedValue({ token: 'auth0-token', userId: 'auth0|123' }),
 	logout: jest.fn().mockResolvedValue(undefined),
 };
 
@@ -29,21 +31,24 @@ describe('AuthStore', () => {
 	it('sets token correctly', () => {
 		const store = createAuthStore(mockAuthService);
 		const state = store.reducer(store.getInitialState(), {
-			type: 'SET_TOKEN',
+			type: 'SET_SESSION',
 			token: 'test-token',
+			userId: 'auth0|test-user',
 		});
 		expect(state.token).toBe('test-token');
+		expect(state.userId).toBe('auth0|test-user');
 	});
 
 	it('logs out correctly by resetting token to null', () => {
 		const store = createAuthStore(mockAuthService);
 		const state = store.reducer(
-			{ token: 'existing-token' },
+			{ token: 'existing-token', userId: 'auth0|existing' },
 			{
 				type: 'LOGOUT',
 			},
 		);
 		expect(state.token).toBeNull();
+		expect(state.userId).toBeNull();
 	});
 
 	it('creates typed actions that dispatch reducer events', async () => {
@@ -52,7 +57,7 @@ describe('AuthStore', () => {
 		const actions = store.createActions(dispatch, storage);
 
 		act(() => {
-			actions.setToken('token-from-action');
+			actions.setToken('token-from-action', 'auth0|token-action');
 		});
 
 		await act(async () => {
@@ -61,12 +66,14 @@ describe('AuthStore', () => {
 		});
 
 		expect(dispatch).toHaveBeenCalledWith({
-			type: 'SET_TOKEN',
+			type: 'SET_SESSION',
 			token: 'token-from-action',
+			userId: 'auth0|token-action',
 		});
 		expect(dispatch).toHaveBeenCalledWith({
-			type: 'SET_TOKEN',
+			type: 'SET_SESSION',
 			token: 'auth0-token',
+			userId: 'auth0|123',
 		});
 		expect(dispatch).toHaveBeenCalledWith({ type: 'LOGOUT' });
 	});

--- a/src/stores/AuthStore.ts
+++ b/src/stores/AuthStore.ts
@@ -1,14 +1,16 @@
 import { StorageKey } from '@enums/StorageKey';
 import { Auth0Service, type AuthService } from '@services/Auth0Service';
 import type { StorageService } from '@services/StorageService';
+import { parseJwtUserId } from '@utils/jwtUtils';
 import type { Dispatch } from 'react';
 
 export type AuthState = {
 	token: string | null;
+	userId: string | null;
 };
 
 export type AuthActions = {
-	setToken: (newToken: string | null) => void;
+	setToken: (newToken: string | null, userId?: string | null) => void;
 	login: () => Promise<void>;
 	logout: () => Promise<void>;
 };
@@ -16,7 +18,11 @@ export type AuthActions = {
 export type AuthStore = AuthState & AuthActions;
 
 export type AuthAction =
-	| { type: 'SET_TOKEN'; token: string | null }
+	| {
+			type: 'SET_SESSION';
+			token: string | null;
+			userId: string | null;
+	  }
 	| { type: 'LOGOUT' };
 
 export type AuthStoreFactory = {
@@ -33,6 +39,7 @@ export const createAuthStore = (
 ): AuthStoreFactory => {
 	const initialState: AuthState = {
 		token: null,
+		userId: null,
 	};
 
 	return {
@@ -42,10 +49,14 @@ export const createAuthStore = (
 
 		reducer(state: AuthState, action: AuthAction): AuthState {
 			switch (action.type) {
-				case 'SET_TOKEN':
-					return { ...state, token: action.token };
+				case 'SET_SESSION':
+					return {
+						...state,
+						token: action.token,
+						userId: action.userId,
+					};
 				case 'LOGOUT':
-					return { ...state, token: null };
+					return { ...state, token: null, userId: null };
 			}
 		},
 
@@ -53,26 +64,47 @@ export const createAuthStore = (
 			dispatch: Dispatch<AuthAction>,
 			storage: StorageService,
 		): AuthActions {
-			function setToken(token: string | null) {
-				dispatch({ type: 'SET_TOKEN', token });
-				async function persistToken(): Promise<void> {
+			function setToken(
+				token: string | null,
+				userId?: string | null,
+			) {
+				const derivedUserId = userId ?? parseJwtUserId(token);
+
+				dispatch({
+					type: 'SET_SESSION',
+					token,
+					userId: derivedUserId,
+				});
+				async function persistSession(): Promise<void> {
 					try {
 						await storage.saveItem(token, StorageKey.AuthToken);
+						await storage.saveItem(
+							derivedUserId,
+							StorageKey.AuthUserId,
+						);
 					} catch (error) {
 						console.error(
-							'[AuthStore] Failed to persist auth token:',
+							'[AuthStore] Failed to persist auth session:',
 							error,
 						);
 					}
 				}
 
-				persistToken();
+				persistSession();
 			}
 
 			async function login() {
-				const token = await authService.login();
-				dispatch({ type: 'SET_TOKEN', token });
-				await storage.saveItem(token, StorageKey.AuthToken);
+				const session = await authService.login();
+				dispatch({
+					type: 'SET_SESSION',
+					token: session.token,
+					userId: session.userId,
+				});
+				await storage.saveItem(session.token, StorageKey.AuthToken);
+				await storage.saveItem(
+					session.userId,
+					StorageKey.AuthUserId,
+				);
 			}
 
 			async function logout() {
@@ -86,6 +118,7 @@ export const createAuthStore = (
 				}
 				dispatch({ type: 'LOGOUT' });
 				await storage.clearItem(StorageKey.AuthToken);
+				await storage.clearItem(StorageKey.AuthUserId);
 			}
 
 			return { setToken, login, logout };

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -8,6 +8,7 @@ export type AccountType =
 
 export type Account = {
 	id: string;
+	ownerId: string | null;
 	name: string;
 	accountType: AccountType;
 	currency: string;
@@ -16,6 +17,7 @@ export type Account = {
 };
 
 export type NewAccountInput = {
+	ownerId?: string | null;
 	name: string;
 	accountType?: AccountType;
 	currency?: string;

--- a/src/types/Budget.ts
+++ b/src/types/Budget.ts
@@ -1,5 +1,6 @@
 export type Budget = {
 	id: string;
+	ownerId: string | null;
 	name: string;
 	amount: number;
 	categoryId: string | null;
@@ -10,6 +11,7 @@ export type Budget = {
 };
 
 export type NewBudgetInput = {
+	ownerId?: string | null;
 	name: string;
 	amount: number;
 	categoryId?: string | null;

--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -1,5 +1,6 @@
 export type Category = {
 	id: string;
+	ownerId: string | null;
 	name: string;
 	color: string | null;
 	icon: string | null;
@@ -8,6 +9,7 @@ export type Category = {
 };
 
 export type NewCategoryInput = {
+	ownerId?: string | null;
 	name: string;
 	color?: string | null;
 	icon?: string | null;

--- a/src/types/Transaction.ts
+++ b/src/types/Transaction.ts
@@ -2,6 +2,7 @@ export type TransactionType = 'expense' | 'income' | 'transfer';
 
 export type Transaction = {
 	id: string;
+	ownerId: string | null;
 	accountId: string | null;
 	amount: number;
 	merchant: string | null;
@@ -15,6 +16,7 @@ export type Transaction = {
 };
 
 export type NewTransactionInput = {
+	ownerId?: string | null;
 	accountId?: string | null;
 	amount: number;
 	merchant?: string | null;

--- a/src/usecases/clearTransactions.ts
+++ b/src/usecases/clearTransactions.ts
@@ -3,7 +3,7 @@ import { TransactionRepository } from '@repositories/TransactionRepository';
 export class ClearTransactions {
 	constructor(private transactionRepo: TransactionRepository) {}
 
-	execute(): Promise<void> {
-		return this.transactionRepo.clearAll();
+	async execute(): Promise<void> {
+		await this.transactionRepo.clearAll();
 	}
 }

--- a/src/usecases/deleteTransaction.ts
+++ b/src/usecases/deleteTransaction.ts
@@ -3,7 +3,7 @@ import { TransactionRepository } from '@repositories/TransactionRepository';
 export class DeleteTransaction {
 	constructor(private transactionRepo: TransactionRepository) {}
 
-	execute(id: string): Promise<void> {
-		return this.transactionRepo.delete(id);
+	async execute(id: string): Promise<void> {
+		await this.transactionRepo.delete(id);
 	}
 }

--- a/src/utils/jwtUtils.ts
+++ b/src/utils/jwtUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * Extracts the `sub` (subject / user ID) claim from a JWT without a library.
+ * Returns null if the token is missing, malformed, or lacks a sub claim.
+ */
+export function parseJwtUserId(
+	token: string | null | undefined,
+): string | null {
+	if (!token) {
+		return null;
+	}
+
+	try {
+		const parts = token.split('.');
+		if (parts.length !== 3) {
+			return null;
+		}
+
+		// Base64url → base64 → JSON
+		let base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+		while (base64.length % 4 !== 0) {
+			base64 += '=';
+		}
+
+		if (typeof globalThis.atob !== 'function') {
+			return null;
+		}
+
+		const json = globalThis.atob(base64);
+		const payload = JSON.parse(json) as Record<string, unknown>;
+
+		return typeof payload.sub === 'string' ? payload.sub : null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
This pull request introduces support for multi-user data separation by adding an `owner_id` field to key database tables and updating the codebase to backfill and persist this field for existing and new records. It also improves authentication state management by persisting and restoring both the authentication token and user ID, and ensures that repositories and hooks are aware of the current user. The changes are well-tested with new and updated unit tests.

**Database schema and migration updates:**

- Added an `owner_id` column to the `accounts`, `transactions`, `categories`, and `budgets` tables, including migration logic to add the column if it does not exist and to create the field in new tables. [[1]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R9) [[2]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R91) [[3]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R112) [[4]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R125) [[5]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R179-R184) [[6]](diffhunk://#diff-0f9f6f7bc7604b89a9055bdb7d7185cdf527d2147b313edde961f4e5a310cd44R201-R227)

**Authentication state management:**

- Updated the authentication provider and store to persist and restore both the authentication token and the authenticated user's ID (`userId`). The `StorageKey` enum and related logic were updated to support this. [[1]](diffhunk://#diff-38a15b277b7f1090f58e9c5204110e050fb35e8e13390beaa64b803e66ddb4b6R3) [[2]](diffhunk://#diff-b8e1ba3cd75ceedf0d4e2b54d10a5755337ff83d078d62cac030fea737b469aeR48-R55) [[3]](diffhunk://#diff-48296fc2e6aab36d1324574ee3f62326cd915c8acc16198e6a684d5f2a79df52L9-R30) [[4]](diffhunk://#diff-48296fc2e6aab36d1324574ee3f62326cd915c8acc16198e6a684d5f2a79df52R42-R72) [[5]](diffhunk://#diff-48296fc2e6aab36d1324574ee3f62326cd915c8acc16198e6a684d5f2a79df52L54-R92) [[6]](diffhunk://#diff-48296fc2e6aab36d1324574ee3f62326cd915c8acc16198e6a684d5f2a79df52R102-R118) [[7]](diffhunk://#diff-48296fc2e6aab36d1324574ee3f62326cd915c8acc16198e6a684d5f2a79df52R131-R161)

**Data backfill and user-awareness:**

- Introduced a new `useBackfillOwnerId` hook to backfill the `owner_id` field for all existing records when a user logs in, ensuring legacy data is associated with the current user. The hook is invoked in the root navigation stack. [[1]](diffhunk://#diff-932ccbe938ac3c21b744607e94083ec333986ef2f28c16e1cee755b41e248916R1-R65) [[2]](diffhunk://#diff-e458468b8029056757087c21d480837163bbaa5a3aa96fa14de34d68785aa93dR4) [[3]](diffhunk://#diff-e458468b8029056757087c21d480837163bbaa5a3aa96fa14de34d68785aa93dR16-R19)
- Added comprehensive unit tests for the `useBackfillOwnerId` hook to verify correct backfilling behavior.

**Repository updates:**

- Updated `AccountRepository` to be aware of the current user ID and to read/write the `owner_id` field for all operations, including creation and listing of accounts. [[1]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddL12-R15) [[2]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddR30) [[3]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddR39) [[4]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddR51) [[5]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddR65-R94) [[6]](diffhunk://#diff-2b40745dd5bd5a2c31fdba276b8fcf68c35c101ac88f61750586e65b31315bddR109)

**Build configuration cleanup:**

- Cleaned up unused `inputPaths` and `outputPaths` entries in the Xcode project configuration for CocoaPods script phases. [[1]](diffhunk://#diff-5f0e0cb7f26f1e2a662d9a8123f25336ac1053e1f537f882de76d75bcbd31aacL194-L201) [[2]](diffhunk://#diff-5f0e0cb7f26f1e2a662d9a8123f25336ac1053e1f537f882de76d75bcbd31aacL237-L244)